### PR TITLE
Add support for new ui for adding, editing assets and uploading files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ docs/.vuepress/dist
 
 assets/elevator-ui/*
 !assets/elevator-ui/dist
+certs
+REVISION

--- a/application/controllers/Asset.php
+++ b/application/controllers/Asset.php
@@ -147,6 +147,7 @@ class asset extends Instance_Controller {
 				}
 			}
 			
+			$json["assetId"] = $assetModel->getObjectId();
 			$json["firstFileHandlerId"] = $targetFileObjectId; // always a file
 			$json["firstObjectId"] = $targetObjectId; // always an asset
 			$json["title"] = $assetModel->getAssetTitle();

--- a/application/controllers/AssetManager.php
+++ b/application/controllers/AssetManager.php
@@ -451,7 +451,11 @@ class AssetManager extends Admin_Controller {
 	}
 
 	// List all of the assets touched by the user.  Offset specifies page number essentially.
-	public function userAssets($offset=0) {
+	public function userAssets($offset=0, $returnJson = false) {
+		if ($this->isUsingVueUI() && !$returnJson) {
+			return $this->template->publish('vueTemplate');
+		}
+
 		if(!isset($this->instance) || !$this->user_model->userLoaded) { 
 			instance_redirect("errorHandler/error/noPermission");
 		}

--- a/application/controllers/AssetManager.php
+++ b/application/controllers/AssetManager.php
@@ -56,6 +56,9 @@ class AssetManager extends Admin_Controller {
 	 */
 	public function addAsset($templateId=null, $collectionId = null, $inlineForm = false)
 	{
+		if ($this->isUsingVueUI()) {
+			return $this->template->publish('vueTemplate');
+		}
 
 		$accessLevel = max($this->user_model->getAccessLevel("instance",$this->instance), $this->user_model->getMaxCollectionPermission());
 

--- a/application/controllers/AssetManager.php
+++ b/application/controllers/AssetManager.php
@@ -281,11 +281,17 @@ class AssetManager extends Admin_Controller {
 	}
 
 	// save an asset
-	public function submission() {
+	public function submission($returnJson = false) {
 
 		$accessLevel = max($this->user_model->getAccessLevel("instance",$this->instance), $this->user_model->getMaxCollectionPermission());
 
 		if($accessLevel < PERM_ADDASSETS) {
+			// log this
+			$this->logging->logError("no permission to add asset", $_SERVER);
+			if ($returnJson) {
+				return render_json(["error" => "No permission"], 403);
+			}
+
 			$this->errorhandler_helper->callError("noPermission");
 		}
 
@@ -316,9 +322,6 @@ class AssetManager extends Admin_Controller {
 		}
 
 
-		echo json_encode(["objectId"=>(string)$objectId, "success"=>true]);
-
-
 		if($firstSave) {
 			/**
 			 * BEWARE
@@ -338,6 +341,12 @@ class AssetManager extends Admin_Controller {
 			 * END HACKY STUFF
 			 */
 
+		}
+
+		if ($returnJson) {
+			return render_json(["objectId" => $objectId, "success" => true], 200);
+		} else {
+			echo json_encode(["objectId"=>(string)$objectId, "success"=>true]);
 		}
 	}
 

--- a/application/controllers/AssetManager.php
+++ b/application/controllers/AssetManager.php
@@ -131,6 +131,9 @@ class AssetManager extends Admin_Controller {
 
 
 	function editAsset($objectId, $inlineForm=false) {
+		if ($this->isUsingVueUI()) {
+			return $this->template->publish('vueTemplate');
+		}
 
 		$accessLevel = $this->user_model->getAccessLevel("instance",$this->instance);
 

--- a/application/controllers/AssetManager.php
+++ b/application/controllers/AssetManager.php
@@ -433,7 +433,7 @@ class AssetManager extends Admin_Controller {
 		$fileHandler->deleteFile();
 	}
 
-	public function deleteAsset($objectId) {
+	public function deleteAsset($objectId, $returnJson = false) {
 
 
 		$accessLevel = $this->user_model->getAccessLevel("instance",$this->instance);
@@ -443,6 +443,10 @@ class AssetManager extends Admin_Controller {
 
 		if($accessLevel < PERM_ADDASSETS) {
 			if($this->user_model->getAccessLevel("collection",$this->collection_model->getCollection($this->asset_model->getGlobalValue("collectionId"))) < PERM_ADDASSETS) {
+				if ($returnJson) {
+					return render_json(["error" => "No permission"], 403);
+				}
+
 				$this->errorhandler_helper->callError("noPermission");
 			}
 
@@ -450,6 +454,9 @@ class AssetManager extends Admin_Controller {
 
 		$this->accessLevel = $this->user_model->getAccessLevel("asset", $this->asset_model);
 		if($this->accessLevel < PERM_ADDASSETS) {
+			if ($returnJson) {
+				return render_json(["error" => "No permission"], 403);
+			}
 			$this->errorhandler_helper->callError("noPermission");
 		}
 		$this->search_model->remove($this->asset_model);
@@ -461,6 +468,10 @@ class AssetManager extends Admin_Controller {
 		$qb->andWhere($qb->expr()->eq('s.asset', ':assetId'));
 		$qb->setParameter(':assetId', $objectId);
 		$qb->getQuery()->execute();
+
+		if ($returnJson) {
+			return render_json(["success" => true], 204);
+		}
 
 		instance_redirect("/");
 	}

--- a/application/controllers/AssetManager.php
+++ b/application/controllers/AssetManager.php
@@ -457,10 +457,12 @@ class AssetManager extends Admin_Controller {
 		}
 
 		if(!isset($this->instance) || !$this->user_model->userLoaded) { 
+			if ($returnJson) {
+				return render_json(["error" => "No permission"], 403);
+			}
 			instance_redirect("errorHandler/error/noPermission");
 		}
-		$this->template->javascript->add("assets/datatables/datatables.min.js");
-		$this->template->stylesheet->add("assets/datatables/datatables.min.css");
+
 
 		$qb = $this->doctrine->em->createQueryBuilder();
 		$qb->from("Entity\Asset", 'a')
@@ -483,6 +485,12 @@ class AssetManager extends Admin_Controller {
 			$hiddenAssetArray[] = ["objectId"=>$this->asset_model->getObjectId(), "title"=>$resultCache['title']??"", "readyForDisplay"=>$this->asset_model->getGlobalValue("readyForDisplay"), "templateId"=>$this->asset_model->getGlobalValue("templateId"), "modifiedDate"=>$this->asset_model->getGlobalValue("modified")];
 		}
 
+		if ($returnJson) {
+			return render_json($hiddenAssetArray);
+		}
+
+		$this->template->javascript->add("assets/datatables/datatables.min.js");
+		$this->template->stylesheet->add("assets/datatables/datatables.min.css");
 		if($offset>0) {
 			$this->load->view('user/hiddenAssets', ["isOffset"=>true, "hiddenAssets"=>$hiddenAssetArray]);
 		}

--- a/application/controllers/AssetManager.php
+++ b/application/controllers/AssetManager.php
@@ -470,7 +470,7 @@ class AssetManager extends Admin_Controller {
 		$qb->getQuery()->execute();
 
 		if ($returnJson) {
-			return render_json(["success" => true], 204);
+			return render_json(null, 204);
 		}
 
 		instance_redirect("/");

--- a/application/controllers/Home.php
+++ b/application/controllers/Home.php
@@ -263,6 +263,8 @@ class Home extends Instance_Controller {
 
 		$headerData['useCustomCSS'] = $this->instance->getUseCustomCSS() ?? false;
 
+		$headerData['useVoyagerViewer'] = $this->instance->getUseVoyagerViewer() ?? false;
+
 		return render_json($headerData);
 	}
 

--- a/application/controllers/S3.php
+++ b/application/controllers/S3.php
@@ -33,7 +33,7 @@ class S3 extends Instance_Controller
       $validated = V::validate($data, [
         'collectionId' => [V::required(), V::integer()],
         'fileObjectId' => [V::required(), V::regex('/^[a-zA-Z0-9]+$/')],
-        'contentType' => [V::required(), V::regex('/^[a-zA-Z0-9\/\-\+]+$/')]
+        'contentType' => [V::required(), V::regex('/^[a-z]+\/[a-z0-9\-\+\.]+$/i')]
       ]);
 
       $this->fileObjectId = $validated['fileObjectId'];

--- a/application/controllers/S3.php
+++ b/application/controllers/S3.php
@@ -301,7 +301,9 @@ class S3 extends Instance_Controller
 
   private function buildAWSFilePath($fileObjectId)
   {
-    return "original/{$fileObjectId}-source";
+    // the REVERSED fileObjectId is used to ensure that files are evenly distributed across S3 buckets
+    $reversedId = strrev($fileObjectId);
+    return "original/{$reversedId}-source";
   }
 
 

--- a/application/controllers/S3.php
+++ b/application/controllers/S3.php
@@ -92,10 +92,10 @@ class S3 extends Instance_Controller
 
   public function multipart($uploadId = null, $action = null)
   {
-    $schema = V::rules([
+    $schema = [
       'uploadId' => [V::regex('/^[a-zA-Z0-9\-_\.\+]+$/')],
       'action' => [V::regex('/^(complete|\d+)$/')]
-    ]);
+    ];
 
     try {
       $validated = V::validate([
@@ -138,9 +138,9 @@ class S3 extends Instance_Controller
   {
     try {
       // validate metadata
-      $schema = V::rules([
+      $schema = [
         'metadata' => [V::array()]
-      ]);
+      ];
 
       $validated = V::validate($this->input->post(), $schema);
     } catch (ValidationException $e) {
@@ -171,10 +171,10 @@ class S3 extends Instance_Controller
   private function signPart($uploadId, $partNumber)
   {
     try {
-      $schema = V::rules([
+      $schema = [
         'uploadId' => [V::required(), V::regex('/^[a-zA-Z0-9\-_\.\+]+$/')],
         'partNumber' => [V::required(), V::integer(), V::min(1), V::max(10000)]
-      ]);
+      ];
 
       $validated = V::validate([
         'uploadId' => $uploadId,
@@ -209,9 +209,9 @@ class S3 extends Instance_Controller
   private function getListOfParts($uploadId)
   {
     try {
-      $schema = V::rules([
+      $schema = [
         'uploadId' => [V::required(), V::regex('/^[a-zA-Z0-9\-_\.\+]+$/')]
-      ]);
+      ];
 
       $validated = V::validate(['uploadId' => $uploadId], $schema);
     } catch (ValidationException $e) {
@@ -229,9 +229,9 @@ class S3 extends Instance_Controller
   private function completeMultipartUpload($uploadId)
   {
     try {
-      $schema = V::rules([
+      $schema = [
         'uploadId' => [V::required(), V::regex('/^[a-zA-Z0-9\-_\.\+]+$/')]
-      ]);
+      ];
 
       $validated = V::validate(['uploadId' => $uploadId], $schema);
     } catch (ValidationException $e) {

--- a/application/controllers/S3.php
+++ b/application/controllers/S3.php
@@ -65,9 +65,7 @@ class S3 extends Instance_Controller
       ],
     ]);
 
-    if (!$this->s3Client) {
-      return abort_json(['error' => 'Failed to create S3 client'], 500);
-    }
+// Removed ineffective null check for $this->s3Client.
   }
 
   public function sign()

--- a/application/controllers/S3.php
+++ b/application/controllers/S3.php
@@ -6,22 +6,41 @@ use Aws\S3\MultipartUploader;
 use Aws\S3\ObjectUploader;
 use Aws\S3\S3Client;
 
+if (!function_exists('abort_json')) {
+  // helper for making sure we stop execution
+  // after rendering a JSON response
+  function abort_json($json, $code = 400)
+  {
+    render_json($json, $code);
+    exit; // Ensure no further output is sent
+  }
+}
+
 class S3 extends Instance_Controller
 {
 
   private $collection = null;
   private $s3Client = null;
   private $fileObjectId = null;
+  private $contentType = null;
 
   public function __construct()
   {
     parent::__construct();
-    $this->checkAuthentication();
-    $this->collection = $this->checkCollectionAccess();
+    $currentUser = $this->user_model->user;
+    $this->checkAuthentication($currentUser);
+
+    $collectionId = $this->input->post('collectionId');
+    $this->collection = $this->checkCollectionAccess($collectionId);
 
     // client side should do a request to `assetManager/getFileContainer` to generate a file object ID
     // this will be used for naming the file in S3
-    $this->fileObjectId = $this->checkFileObjectId();
+    $fileObjectId  = $this->input->post('fileObjectId');
+    $this->fileObjectId = $this->checkFileObjectId($fileObjectId);
+
+    $contentType = $this->input->post('contentType');
+    $this->contentType = $this->checkContentTypeParam($contentType);
+
     $this->s3Client = new S3Client([
       'version' => 'latest',
       'region' => $this->collection->getBucketRegion(),
@@ -44,24 +63,11 @@ class S3 extends Instance_Controller
       ], 405);
     }
 
-    $contentType = $this->input->post('contentType');
-    if (!$contentType) {
-      return render_json([
-        'error' => 'contentType parameter is required.'
-      ], 400);
-    }
-
-    if (!preg_match('/^[a-zA-Z0-9\/\-\+]+$/', $contentType)) {
-      return render_json([
-        'error' => 'Invalid content type format.'
-      ], 400);
-    }
-
     try {
       $command = $this->s3Client->getCommand('PutObject', [
         'Bucket' => $this->collection->getBucket(),
         'Key' => $this->getAWSFilePath(),
-        'ContentType' => $contentType
+        'ContentType' => $this->contentType
       ]);
 
       $request = $this->s3Client->createPresignedRequest($command, '+1 hour');
@@ -72,7 +78,7 @@ class S3 extends Instance_Controller
         'method' => 'PUT',
       ]);
     } catch (Exception $e) {
-      return render_json([
+      return abort_json([
         'error' => 'Failed to generate signed URL: ' . $e->getMessage(),
       ], 500);
     }
@@ -83,7 +89,7 @@ class S3 extends Instance_Controller
     $method = $this->input->server('REQUEST_METHOD');
 
     if ($method !== 'POST') {
-      return render_json([
+      return abort_json([
         'error' => 'Method not allowed',
       ], 405);
     }
@@ -109,92 +115,156 @@ class S3 extends Instance_Controller
     }
 
     // If we reach here, it means the request is not valid for multipart operations
-    return render_json([
+    return abort_json([
       'error' => 'Page not found',
     ], 404);
   }
 
+  // POST /s3/multipart - Start a multipart upload
   private function startMultipartUpload()
   {
-    // Logic to start a multipart upload
-    // This would typically involve creating a new upload ID and returning it
+    $metadata = $this->checkMetaData();
+
+    $command = $this->s3Client->getCommand('CreateMultipartUpload', [
+      'Bucket' => $this->collection->getBucket(),
+      'Key' => $this->getAWSFilePath(),
+      'ContentType' => $this->contentType,
+      'Metadata' => $metadata,
+    ]);
+
+    $result = $this->s3Client->execute($command);
+
+    if (!$result || !isset($result['UploadId'])) {
+      return render_json([
+        'error' => 'Failed to start multipart upload',
+      ], 500);
+    }
+
     return render_json([
-      'message' => 'startMultipartUpload',
-      'uploadId' => uniqid('upload_') // Example upload ID
+      "message" => "Multipart upload started successfully",
+      "uploadId" => $result['UploadId'],
+      "key" => $this->getAWSFilePath(),
     ]);
   }
 
   // GET /s3/mutipart/{uploadId}/{partNumber} - get a signed URL for a specific part of a multipart upload
   private function getSignedUrlForPart($uploadId, $partNumber)
   {
-    return render_json([
-      'message' => 'getSignedUrlForPart',
-      'uploadId' => $uploadId,
-      'partNumber' => $partNumber
-    ]);
+    $uploadId = $this->checkUploadId($uploadId);
+    $partNumber = $this->checkPartNumber($partNumber);
+
+    try {
+      $command = $this->s3Client->getCommand('UploadPart', [
+        'Bucket' => $this->collection->getBucket(),
+        'Key' => $this->getAWSFilePath(),
+        'UploadId' => $uploadId,
+        'PartNumber' => $partNumber,
+      ]);
+
+      $result = $this->s3Client->createPresignedRequest($command, '+1 hour');
+
+      return render_json([
+        'method' => 'PUT',
+        'url' => (string)$result->getUri()
+      ]);
+    } catch (MultipartUploadException $e) {
+      return abort_json([
+        'error' => 'Failed to get signed URL for part: ' . $e->getMessage(),
+      ], 500);
+    }
   }
 
   // GET /s3/multipart/{uploadId} - Get a list of uploaded parts and etags
   private function getListOfParts($uploadId)
   {
-    return render_json([
-      'message' => 'getListOfParts',
-      'uploadId' => $uploadId
-    ]);
+    $uploadId = $this->checkUploadId($uploadId);
+
+    try {
+      $command = $this->s3Client->getCommand('ListParts', [
+        'Bucket' => $this->collection->getBucket(),
+        'Key' => $this->getAWSFilePath(),
+        'UploadId' => $uploadId,
+      ]);
+
+      $result = $this->s3Client->execute($command);
+
+      return render_json([
+        'parts' => $result['Parts'] ?? [],
+      ]);
+    } catch (MultipartUploadException $e) {
+      return abort_json([
+        'error' => 'Failed to list parts: ' . $e->getMessage(),
+      ], 500);
+    }
   }
 
   // POST /s3/mutlipart/{uploadId}/complete - Complete a multipart upload
   private function completeMultipartUpload($uploadId)
   {
-    return render_json([
-      'message' => 'completeMultipartUpload',
-      'uploadId' => $uploadId
-    ]);
-  }
+    $parts = $this->checkUploadParts($this->input->post('parts'));
 
-  private function checkAuthentication()
-  {
-    if (!$this->user_model->user) {
+    try {
+      $command = $this->s3Client->getCommand('CompleteMultipartUpload', [
+        'Bucket' => $this->collection->getBucket(),
+        'Key' => $this->getAWSFilePath(),
+        'UploadId' => $uploadId,
+        'MultipartUpload' => [
+          'Parts' => $parts
+        ]
+      ]);
+
+      $result = $this->s3Client->execute($command);
+
       return render_json([
-        'error' => 'You must be logged in to perform this action.'
-      ], 401);
-      exit;
+        'message' => 'completeMultipartUpload',
+        'Location' => $result['Location'] ?? null,
+      ]);
+    } catch (MultipartUploadException $e) {
+      return abort_json([
+        'error' => 'Failed to complete multipart upload: ' . $e->getMessage(),
+      ], 500);
     }
   }
 
-  private function checkFileObjectId()
+  private function checkAuthentication($user)
   {
-    $fileObjectId = $this->input->post('fileObjectId');
+    if (!$user) {
+      return abort_json([
+        'error' => 'You must be logged in to perform this action.'
+      ], 401);
+    }
+  }
+
+  private function checkFileObjectId(
+    $fileObjectId = null
+  ) {
     if (!$fileObjectId) {
-      return render_json([
+      return abort_json([
         'error' => 'File Object ID parameter is required.'
       ], 400);
-      exit;
     }
 
     return $fileObjectId;
   }
 
-  private function checkCollectionAccess()
+  private function checkCollectionAccess($collectionId = null)
   {
-    $collectionId = $this->input->post('collectionId');
     if (!$collectionId) {
-      return render_json([
+      return abort_json([
         'error' => 'Collection ID parameter is required.'
       ], 400);
-      exit;
     }
 
     $collection = $this->collection_model->getCollection($collectionId);
     if (!$collection) {
-      return render_json([
+      return abort_json([
         'error' => 'Collection not found: ' . $collectionId
       ], 404);
     }
 
 
     if (!$this->canUploadToCollection($collection)) {
-      render_json([
+      return abort_json([
         'error' => 'You do not have permission to upload to this collection.'
       ], 403);
     }
@@ -225,5 +295,75 @@ class S3 extends Instance_Controller
     }
 
     return "original/{$this->fileObjectId}-source";
+  }
+
+  private function checkContentTypeParam($contentType = null)
+  {
+    if (!$contentType) {
+      return abort_json([
+        'error' => 'Missing contentType param.'
+      ], 400);
+    }
+
+    if (!preg_match('/^[a-zA-Z0-9\/\-\+]+$/', $contentType)) {
+      return abort_json([
+        'error' => 'Invalid contentType param.'
+      ], 400);
+    }
+
+    return $contentType;
+  }
+
+  private function checkMetadata($metadata = null)
+  {
+    if (!$metadata) {
+      return [];
+    }
+
+    if (is_string($metadata)) {
+      $metadata = json_decode($metadata, true);
+    }
+
+    if (!is_array($metadata)) {
+      return abort_json(
+        ['error' => 'metadata must be a valid JSON object.']
+      );
+    }
+
+    return $metadata;
+  }
+
+  private function checkUploadId($uploadId = null)
+  {
+    if (!$uploadId || !preg_match('/^[a-zA-Z0-9\-_\.\+]+$/', $uploadId)) {
+      return abort_json(['error' => 'Invalid uploadId parameter.']);
+    }
+    return $uploadId;
+  }
+
+  private function checkPartNumber($partNumber = null)
+  {
+    if (!is_numeric($partNumber) || $partNumber < 1 || $partNumber > 10000) {
+      return abort_json(['error' => 'Invalid partNumber parameter.']);
+    }
+    return (int)$partNumber;
+  }
+
+  private function checkUploadParts($parts = null)
+  {
+    if (!$parts || !is_array($parts)) {
+      return abort_json(['error' => 'Parts parameter is required and must be an array.']);
+    }
+
+    foreach ($parts as $part) {
+      if (!isset($part['PartNumber']) || !isset($part['ETag'])) {
+        return abort_json(['error' => 'Each part must have a PartNumber and ETag.']);
+      }
+      if (!is_numeric($part['PartNumber']) || !preg_match('/^[a-zA-Z0-9\-]+$/', $part['ETag'])) {
+        return abort_json(['error' => 'Invalid PartNumber or ETag format.']);
+      }
+    }
+
+    return $parts;
   }
 }

--- a/application/controllers/S3.php
+++ b/application/controllers/S3.php
@@ -1,0 +1,229 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+
+use Aws\Exception\MultipartUploadException;
+use Aws\S3\MultipartUploader;
+use Aws\S3\ObjectUploader;
+use Aws\S3\S3Client;
+
+class S3 extends Instance_Controller
+{
+
+  private $collection = null;
+  private $s3Client = null;
+  private $fileObjectId = null;
+
+  public function __construct()
+  {
+    parent::__construct();
+    $this->checkAuthentication();
+    $this->collection = $this->checkCollectionAccess();
+
+    // client side should do a request to `assetManager/getFileContainer` to generate a file object ID
+    // this will be used for naming the file in S3
+    $this->fileObjectId = $this->checkFileObjectId();
+    $this->s3Client = new S3Client([
+      'version' => 'latest',
+      'region' => $this->collection->getBucketRegion(),
+      'credentials' => [
+        'key' => $this->collection->getS3Key(),
+        'secret' => $this->collection->getS3Secret(),
+      ],
+    ]);
+  }
+
+
+  // POST /s3/sign - Generate a signed URL for S3 upload (not multipart)
+  public function sign()
+  {
+    $method = $this->input->server('REQUEST_METHOD');
+
+    if ($method !== 'POST') {
+      return render_json([
+        'error' => 'Method not allowed',
+      ], 405);
+    }
+
+    $contentType = $this->input->post('contentType');
+    if (!$contentType) {
+      return render_json([
+        'error' => 'contentType parameter is required.'
+      ], 400);
+    }
+
+    if (!preg_match('/^[a-zA-Z0-9\/\-\+]+$/', $contentType)) {
+      return render_json([
+        'error' => 'Invalid content type format.'
+      ], 400);
+    }
+
+    try {
+      $command = $this->s3Client->getCommand('PutObject', [
+        'Bucket' => $this->collection->getBucket(),
+        'Key' => $this->getAWSFilePath(),
+        'ContentType' => $contentType
+      ]);
+
+      $request = $this->s3Client->createPresignedRequest($command, '+1 hour');
+      $signedUrl = (string) $request->getUri();
+
+      return render_json([
+        'url' => $signedUrl,
+        'method' => 'PUT',
+      ]);
+    } catch (Exception $e) {
+      return render_json([
+        'error' => 'Failed to generate signed URL: ' . $e->getMessage(),
+      ], 500);
+    }
+  }
+
+  public function multipart($uploadId = null, $partNumberOrComplete = null)
+  {
+    $method = $this->input->server('REQUEST_METHOD');
+
+    if ($method !== 'POST') {
+      return render_json([
+        'error' => 'Method not allowed',
+      ], 405);
+    }
+
+    // POST /s3/multipart - Start a multipart upload
+    if ($uploadId === null && $partNumberOrComplete === null) {
+      return $this->startMultipartUpload();
+    }
+
+    // POST /s3/multipart/{uploadId}
+    if ($uploadId !== null && $partNumberOrComplete === null) {
+      return $this->getListOfParts($uploadId);
+    }
+
+    // POST /s3/multipart/{uploadId}/{partNumber}
+    if ($uploadId !== null && is_numeric($partNumberOrComplete)) {
+      return $this->getSignedUrlForPart($uploadId, $partNumberOrComplete);
+    }
+
+    // POST /s3/multipart/{uploadId}/complete
+    if ($uploadId !== null && strtolower($partNumberOrComplete) === 'complete') {
+      return $this->completeMultipartUpload($uploadId);
+    }
+
+    // If we reach here, it means the request is not valid for multipart operations
+    return render_json([
+      'error' => 'Page not found',
+    ], 404);
+  }
+
+  private function startMultipartUpload()
+  {
+    // Logic to start a multipart upload
+    // This would typically involve creating a new upload ID and returning it
+    return render_json([
+      'message' => 'startMultipartUpload',
+      'uploadId' => uniqid('upload_') // Example upload ID
+    ]);
+  }
+
+  // GET /s3/mutipart/{uploadId}/{partNumber} - get a signed URL for a specific part of a multipart upload
+  private function getSignedUrlForPart($uploadId, $partNumber)
+  {
+    return render_json([
+      'message' => 'getSignedUrlForPart',
+      'uploadId' => $uploadId,
+      'partNumber' => $partNumber
+    ]);
+  }
+
+  // GET /s3/multipart/{uploadId} - Get a list of uploaded parts and etags
+  private function getListOfParts($uploadId)
+  {
+    return render_json([
+      'message' => 'getListOfParts',
+      'uploadId' => $uploadId
+    ]);
+  }
+
+  // POST /s3/mutlipart/{uploadId}/complete - Complete a multipart upload
+  private function completeMultipartUpload($uploadId)
+  {
+    return render_json([
+      'message' => 'completeMultipartUpload',
+      'uploadId' => $uploadId
+    ]);
+  }
+
+  private function checkAuthentication()
+  {
+    if (!$this->user_model->user) {
+      return render_json([
+        'error' => 'You must be logged in to perform this action.'
+      ], 401);
+      exit;
+    }
+  }
+
+  private function checkFileObjectId()
+  {
+    $fileObjectId = $this->input->post('fileObjectId');
+    if (!$fileObjectId) {
+      return render_json([
+        'error' => 'File Object ID parameter is required.'
+      ], 400);
+      exit;
+    }
+
+    return $fileObjectId;
+  }
+
+  private function checkCollectionAccess()
+  {
+    $collectionId = $this->input->post('collectionId');
+    if (!$collectionId) {
+      return render_json([
+        'error' => 'Collection ID parameter is required.'
+      ], 400);
+      exit;
+    }
+
+    $collection = $this->collection_model->getCollection($collectionId);
+    if (!$collection) {
+      return render_json([
+        'error' => 'Collection not found: ' . $collectionId
+      ], 404);
+    }
+
+
+    if (!$this->canUploadToCollection($collection)) {
+      render_json([
+        'error' => 'You do not have permission to upload to this collection.'
+      ], 403);
+    }
+
+    return $collection;
+  }
+
+  private function canUploadToCollection($collection)
+  {
+    if (!$collection) {
+      throw new InvalidArgumentException('Collection cannot be null');
+    }
+
+    if ($this->user_model->getIsSuperAdmin()) {
+      return true;
+    }
+
+    $accessLevel = $this->user_model->getAccessLevel("collection", $collection);
+
+    return $accessLevel >= PERM_ADDASSETS;
+  }
+
+  // aka the `key` in S3 terms
+  private function getAWSFilePath()
+  {
+    if (!$this->fileObjectId) {
+      throw new Exception('File Object ID Not Set');
+    }
+
+    return "original/{$this->fileObjectId}-source";
+  }
+}

--- a/application/controllers/S3.php
+++ b/application/controllers/S3.php
@@ -46,8 +46,6 @@ class S3 extends Instance_Controller
     // get collection
     $this->collection = $this->collection_model->getCollection($this->collectionId);
 
-    var_dump($this->collection);
-
     if (!$this->collection) {
       return abort_json(['error' => 'Collection not found'], 404);
     }
@@ -256,7 +254,7 @@ class S3 extends Instance_Controller
 
       return render_json([
         'message' => 'completeMultipartUpload',
-        'Location' => $result['Location'] ?? null,
+        'location' => $result['Location'] ?? null,
       ]);
     } catch (MultipartUploadException $e) {
       return abort_json(['error' => 'Failed to complete multipart upload: ' . $e->getMessage()], 500);

--- a/application/controllers/S3.php
+++ b/application/controllers/S3.php
@@ -2,46 +2,63 @@
 defined('BASEPATH') or exit('No direct script access allowed');
 
 use Aws\Exception\MultipartUploadException;
-use Aws\S3\MultipartUploader;
-use Aws\S3\ObjectUploader;
 use Aws\S3\S3Client;
-
-if (!function_exists('abort_json')) {
-  // helper for making sure we stop execution
-  // after rendering a JSON response
-  function abort_json($json, $code = 400)
-  {
-    render_json($json, $code);
-    exit; // Ensure no further output is sent
-  }
-}
+use SimpleValidator as V;
 
 class S3 extends Instance_Controller
 {
-
-  private $collection = null;
-  private $s3Client = null;
-  private $fileObjectId = null;
-  private $contentType = null;
+  protected $fileObjectId;
+  protected $contentType;
+  protected $s3Client;
+  protected $collectionId;
+  protected $collection;
 
   public function __construct()
   {
     parent::__construct();
-    $currentUser = $this->user_model->user;
-    $this->checkAuthentication($currentUser);
+    $this->load->library('SimpleValidator');
 
-    $collectionId = $this->input->post('collectionId');
-    $this->collection = $this->checkCollectionAccess($collectionId);
+    if (!$this->isUserAuthenticated()) {
+      return abort_json(['error' => 'Unauthorized'], 401);
+    }
 
-    // client side should do a request to `assetManager/getFileContainer` to generate a file object ID
-    // this will be used for naming the file in S3
-    $fileObjectId  = $this->input->post('fileObjectId');
-    $this->fileObjectId = $this->checkFileObjectId($fileObjectId);
+    if ($this->input->method() !== 'post') {
+      return abort_json(['error' => 'Method not allowed'], 405);
+    }
 
-    $contentType = $this->input->post('contentType');
-    $this->contentType = $this->checkContentTypeParam($contentType);
+    // setup instance variables common to all methods
+    $data = $this->input->post();
 
-    $this->s3Client = new S3Client([
+    try {
+      $validated = V::validate($data, [
+        'collectionId' => [V::required(), V::integer()],
+        'fileObjectId' => [V::required(), V::regex('/^[a-zA-Z0-9]+$/')],
+        'contentType' => [V::required(), V::regex('/^[a-zA-Z0-9\/\-\+]+$/')]
+      ]);
+
+      $this->fileObjectId = $validated['fileObjectId'];
+      $this->contentType = $validated['contentType'];
+      $this->collectionId = $validated['collectionId'];
+    } catch (ValidationException $e) {
+      return abort_json(['errors' => $e->getErrors()], 400);
+    }
+
+    // get collection
+    $this->collection = $this->collection_model->getCollection($this->collectionId);
+
+    var_dump($this->collection);
+
+    if (!$this->collection) {
+      return abort_json(['error' => 'Collection not found'], 404);
+    }
+
+    // verify user permissions for this collection
+    if (!$this->canUploadToCollection($this->collection)) {
+      return abort_json(['error' => 'You do not have permission to upload to this collection.'], 403);
+    }
+
+    // create S3 client
+    $this->s3Client =  new S3Client([
       'version' => 'latest',
       'region' => $this->collection->getBucketRegion(),
       'credentials' => [
@@ -49,168 +66,190 @@ class S3 extends Instance_Controller
         'secret' => $this->collection->getS3Secret(),
       ],
     ]);
+
+    if (!$this->s3Client) {
+      return abort_json(['error' => 'Failed to create S3 client'], 500);
+    }
   }
 
-
-  // POST /s3/sign - Generate a signed URL for S3 upload (not multipart)
   public function sign()
   {
-    $method = $this->input->server('REQUEST_METHOD');
-
-    if ($method !== 'POST') {
-      return render_json([
-        'error' => 'Method not allowed',
-      ], 405);
-    }
-
     try {
       $command = $this->s3Client->getCommand('PutObject', [
         'Bucket' => $this->collection->getBucket(),
-        'Key' => $this->getAWSFilePath(),
-        'ContentType' => $this->contentType
+        'Key' => $this->buildAWSFilePath($this->fileObjectId),
+        'ContentType' => $this->contentType,
       ]);
 
       $request = $this->s3Client->createPresignedRequest($command, '+1 hour');
-      $signedUrl = (string) $request->getUri();
 
       return render_json([
-        'url' => $signedUrl,
+        'url' => (string)$request->getUri(),
         'method' => 'PUT',
       ]);
     } catch (Exception $e) {
-      return abort_json([
-        'error' => 'Failed to generate signed URL: ' . $e->getMessage(),
-      ], 500);
+      return abort_json(['error' => 'Failed to generate signed URL: ' . $e->getMessage()], 500);
     }
   }
 
-  public function multipart($uploadId = null, $partNumberOrComplete = null)
+  public function multipart($uploadId = null, $action = null)
   {
-    $method = $this->input->server('REQUEST_METHOD');
+    $schema = V::rules([
+      'uploadId' => [V::regex('/^[a-zA-Z0-9\-_\.\+]+$/')],
+      'action' => [V::regex('/^(complete|\d+)$/')]
+    ]);
 
-    if ($method !== 'POST') {
-      return abort_json([
-        'error' => 'Method not allowed',
-      ], 405);
+    try {
+      $validated = V::validate([
+        'uploadId' => $uploadId,
+        'action' => $action
+      ], $schema);
+    } catch (ValidationException $e) {
+      return abort_json(['errors' => $e->getErrors()], 400);
     }
 
-    // POST /s3/multipart - Start a multipart upload
-    if ($uploadId === null && $partNumberOrComplete === null) {
-      return $this->startMultipartUpload();
-    }
+    $uploadId = $validated['uploadId'] ?? null;
+    $action = $validated['action'] ?? null;
+    switch (true) {
+      case $uploadId === null:
+        // POST /s3/multipart
+        // start a new multipart upload
+        return $this->startMultipartUpload();
 
-    // POST /s3/multipart/{uploadId}
-    if ($uploadId !== null && $partNumberOrComplete === null) {
-      return $this->getListOfParts($uploadId);
-    }
+      case $action === null:
+        // POST /s3/multipart/{uploadId}
+        // list parts of an existing multipart upload
+        return $this->getListOfParts($uploadId);
 
-    // POST /s3/multipart/{uploadId}/{partNumber}
-    if ($uploadId !== null && is_numeric($partNumberOrComplete)) {
-      return $this->getSignedUrlForPart($uploadId, $partNumberOrComplete);
-    }
+        // POST /s3/multipart/{uploadId}/{partNumber}
+        // get signed url for a part
+      case ctype_digit($action):
+        return $this->signPart($uploadId, (int) $action);
 
-    // POST /s3/multipart/{uploadId}/complete
-    if ($uploadId !== null && strtolower($partNumberOrComplete) === 'complete') {
-      return $this->completeMultipartUpload($uploadId);
-    }
+        // POST /s3/multipart/{uploadId}/complete
+        // complete the multipart upload
+      case strtolower($action) === 'complete':
+        return $this->completeMultipartUpload($uploadId);
 
-    // If we reach here, it means the request is not valid for multipart operations
-    return abort_json([
-      'error' => 'Page not found',
-    ], 404);
+      default:
+        return abort_json(['error' => 'Page not found'], 404);
+    }
   }
 
-  // POST /s3/multipart - Start a multipart upload
   private function startMultipartUpload()
   {
-    $metadata = $this->checkMetaData();
-
-    $command = $this->s3Client->getCommand('CreateMultipartUpload', [
-      'Bucket' => $this->collection->getBucket(),
-      'Key' => $this->getAWSFilePath(),
-      'ContentType' => $this->contentType,
-      'Metadata' => $metadata,
-    ]);
-
-    $result = $this->s3Client->execute($command);
-
-    if (!$result || !isset($result['UploadId'])) {
-      return render_json([
-        'error' => 'Failed to start multipart upload',
-      ], 500);
-    }
-
-    return render_json([
-      "message" => "Multipart upload started successfully",
-      "uploadId" => $result['UploadId'],
-      "key" => $this->getAWSFilePath(),
-    ]);
-  }
-
-  // GET /s3/mutipart/{uploadId}/{partNumber} - get a signed URL for a specific part of a multipart upload
-  private function getSignedUrlForPart($uploadId, $partNumber)
-  {
-    $uploadId = $this->checkUploadId($uploadId);
-    $partNumber = $this->checkPartNumber($partNumber);
-
     try {
-      $command = $this->s3Client->getCommand('UploadPart', [
-        'Bucket' => $this->collection->getBucket(),
-        'Key' => $this->getAWSFilePath(),
-        'UploadId' => $uploadId,
-        'PartNumber' => $partNumber,
+      // validate metadata
+      $schema = V::rules([
+        'metadata' => [V::array()]
       ]);
 
-      $result = $this->s3Client->createPresignedRequest($command, '+1 hour');
-
-      return render_json([
-        'method' => 'PUT',
-        'url' => (string)$result->getUri()
-      ]);
-    } catch (MultipartUploadException $e) {
-      return abort_json([
-        'error' => 'Failed to get signed URL for part: ' . $e->getMessage(),
-      ], 500);
+      $validated = V::validate($this->input->post(), $schema);
+    } catch (ValidationException $e) {
+      return abort_json(['errors' => $e->getErrors()], 400);
     }
-  }
 
-  // GET /s3/multipart/{uploadId} - Get a list of uploaded parts and etags
-  private function getListOfParts($uploadId)
-  {
-    $uploadId = $this->checkUploadId($uploadId);
-
+    // start multipart upload
     try {
-      $command = $this->s3Client->getCommand('ListParts', [
+      $command = $this->s3Client->getCommand('CreateMultipartUpload', [
         'Bucket' => $this->collection->getBucket(),
-        'Key' => $this->getAWSFilePath(),
-        'UploadId' => $uploadId,
+        'Key' => $this->buildAWSFilePath($this->fileObjectId),
+        'ContentType' => $this->contentType,
+        'Metadata' => $validated['metadata'] ?? [],
       ]);
 
       $result = $this->s3Client->execute($command);
 
       return render_json([
-        'parts' => $result['Parts'] ?? [],
+        "message" => "Multipart upload started successfully",
+        "uploadId" => $result['UploadId'],
+        "key" => $this->buildAWSFilePath($this->fileObjectId),
       ]);
-    } catch (MultipartUploadException $e) {
-      return abort_json([
-        'error' => 'Failed to list parts: ' . $e->getMessage(),
-      ], 500);
+    } catch (Exception $e) {
+      return abort_json(['error' => 'Failed to start multipart upload: ' . $e->getMessage()], 500);
     }
   }
 
-  // POST /s3/mutlipart/{uploadId}/complete - Complete a multipart upload
+  private function signPart($uploadId, $partNumber)
+  {
+    try {
+      $schema = V::rules([
+        'uploadId' => [V::required(), V::regex('/^[a-zA-Z0-9\-_\.\+]+$/')],
+        'partNumber' => [V::required(), V::integer(), V::min(1), V::max(10000)]
+      ]);
+
+      $validated = V::validate([
+        'uploadId' => $uploadId,
+        'partNumber' => $partNumber
+      ], $schema);
+    } catch (ValidationException $e) {
+      return abort_json(['errors' => $e->getErrors()], 422);
+    }
+
+    try {
+      $command = $this->s3Client->getCommand('UploadPart', [
+        'Bucket' => $this->collection->getBucket(),
+        'Key' => $this->buildAWSFilePath($this->fileObjectId),
+        'UploadId' => $validated['uploadId'],
+        'PartNumber' => $validated['partNumber'],
+      ]);
+
+      $result = $this->s3Client->createPresignedRequest($command, '+1 hour');
+
+      return render_json([
+        'message' => 'signPart',
+        'url' => (string)$result->getUri(),
+        'method' => 'PUT',
+        'partNumber' => $validated['partNumber'],
+        'uploadId' => $validated['uploadId'],
+      ]);
+    } catch (Exception $e) {
+      return abort_json(['error' => 'Failed to sign part: ' . $e->getMessage()], 500);
+    }
+  }
+
+  private function getListOfParts($uploadId)
+  {
+    try {
+      $schema = V::rules([
+        'uploadId' => [V::required(), V::regex('/^[a-zA-Z0-9\-_\.\+]+$/')]
+      ]);
+
+      $validated = V::validate(['uploadId' => $uploadId], $schema);
+    } catch (ValidationException $e) {
+      return abort_json(['errors' => $e->getErrors()], 400);
+    }
+
+    try {
+      $parts = $this->getUploadParts($validated['uploadId']);
+      return render_json(['parts' => $parts]);
+    } catch (MultipartUploadException $e) {
+      return abort_json(['error' => 'Failed to list parts: ' . $e->getMessage()], 500);
+    }
+  }
+
   private function completeMultipartUpload($uploadId)
   {
-    $parts = $this->checkUploadParts($this->input->post('parts'));
+    try {
+      $schema = V::rules([
+        'uploadId' => [V::required(), V::regex('/^[a-zA-Z0-9\-_\.\+]+$/')]
+      ]);
+
+      $validated = V::validate(['uploadId' => $uploadId], $schema);
+    } catch (ValidationException $e) {
+      return abort_json(['errors' => $e->getErrors()], 400);
+    }
+
+    $parts = $this->getUploadParts(
+      $validated['uploadId']
+    );
 
     try {
       $command = $this->s3Client->getCommand('CompleteMultipartUpload', [
         'Bucket' => $this->collection->getBucket(),
-        'Key' => $this->getAWSFilePath(),
-        'UploadId' => $uploadId,
-        'MultipartUpload' => [
-          'Parts' => $parts
-        ]
+        'Key' => $this->buildAWSFilePath($this->fileObjectId),
+        'UploadId' => $validated['uploadId'],
+        'MultipartUpload' => ['Parts' => $parts]
       ]);
 
       $result = $this->s3Client->execute($command);
@@ -220,62 +259,40 @@ class S3 extends Instance_Controller
         'Location' => $result['Location'] ?? null,
       ]);
     } catch (MultipartUploadException $e) {
-      return abort_json([
-        'error' => 'Failed to complete multipart upload: ' . $e->getMessage(),
-      ], 500);
+      return abort_json(['error' => 'Failed to complete multipart upload: ' . $e->getMessage()], 500);
     }
   }
 
-  private function checkAuthentication($user)
+  private function isUserAuthenticated()
   {
-    if (!$user) {
-      return abort_json([
-        'error' => 'You must be logged in to perform this action.'
-      ], 401);
-    }
+    return !!$this->user_model?->user;
   }
 
-  private function checkFileObjectId(
-    $fileObjectId = null
-  ) {
-    if (!$fileObjectId) {
-      return abort_json([
-        'error' => 'File Object ID parameter is required.'
-      ], 400);
-    }
 
-    return $fileObjectId;
-  }
 
-  private function checkCollectionAccess($collectionId = null)
+  private function buildAWSFilePath($fileObjectId)
   {
-    if (!$collectionId) {
-      return abort_json([
-        'error' => 'Collection ID parameter is required.'
-      ], 400);
-    }
-
-    $collection = $this->collection_model->getCollection($collectionId);
-    if (!$collection) {
-      return abort_json([
-        'error' => 'Collection not found: ' . $collectionId
-      ], 404);
-    }
-
-
-    if (!$this->canUploadToCollection($collection)) {
-      return abort_json([
-        'error' => 'You do not have permission to upload to this collection.'
-      ], 403);
-    }
-
-    return $collection;
+    return "original/{$fileObjectId}-source";
   }
+
+
+  private function getUploadParts($uploadId)
+  {
+    $command = $this->s3Client->getCommand('ListParts', [
+      'Bucket' => $this->collection->getBucket(),
+      'Key' => $this->buildAWSFilePath($this->fileObjectId),
+      'UploadId' => $uploadId,
+    ]);
+
+    $result = $this->s3Client->execute($command);
+    return $result['Parts'] ?? [];
+  }
+
 
   private function canUploadToCollection($collection)
   {
     if (!$collection) {
-      throw new InvalidArgumentException('Collection cannot be null');
+      return false;
     }
 
     if ($this->user_model->getIsSuperAdmin()) {
@@ -283,87 +300,6 @@ class S3 extends Instance_Controller
     }
 
     $accessLevel = $this->user_model->getAccessLevel("collection", $collection);
-
     return $accessLevel >= PERM_ADDASSETS;
-  }
-
-  // aka the `key` in S3 terms
-  private function getAWSFilePath()
-  {
-    if (!$this->fileObjectId) {
-      throw new Exception('File Object ID Not Set');
-    }
-
-    return "original/{$this->fileObjectId}-source";
-  }
-
-  private function checkContentTypeParam($contentType = null)
-  {
-    if (!$contentType) {
-      return abort_json([
-        'error' => 'Missing contentType param.'
-      ], 400);
-    }
-
-    if (!preg_match('/^[a-zA-Z0-9\/\-\+]+$/', $contentType)) {
-      return abort_json([
-        'error' => 'Invalid contentType param.'
-      ], 400);
-    }
-
-    return $contentType;
-  }
-
-  private function checkMetadata($metadata = null)
-  {
-    if (!$metadata) {
-      return [];
-    }
-
-    if (is_string($metadata)) {
-      $metadata = json_decode($metadata, true);
-    }
-
-    if (!is_array($metadata)) {
-      return abort_json(
-        ['error' => 'metadata must be a valid JSON object.']
-      );
-    }
-
-    return $metadata;
-  }
-
-  private function checkUploadId($uploadId = null)
-  {
-    if (!$uploadId || !preg_match('/^[a-zA-Z0-9\-_\.\+]+$/', $uploadId)) {
-      return abort_json(['error' => 'Invalid uploadId parameter.']);
-    }
-    return $uploadId;
-  }
-
-  private function checkPartNumber($partNumber = null)
-  {
-    if (!is_numeric($partNumber) || $partNumber < 1 || $partNumber > 10000) {
-      return abort_json(['error' => 'Invalid partNumber parameter.']);
-    }
-    return (int)$partNumber;
-  }
-
-  private function checkUploadParts($parts = null)
-  {
-    if (!$parts || !is_array($parts)) {
-      return abort_json(['error' => 'Parts parameter is required and must be an array.']);
-    }
-
-    foreach ($parts as $part) {
-      if (!isset($part['PartNumber']) || !isset($part['ETag'])) {
-        return abort_json(['error' => 'Each part must have a PartNumber and ETag.']);
-      }
-      if (!is_numeric($part['PartNumber']) || !preg_match('/^[a-zA-Z0-9\-]+$/', $part['ETag'])) {
-        return abort_json(['error' => 'Invalid PartNumber or ETag format.']);
-      }
-    }
-
-    return $parts;
   }
 }

--- a/application/controllers/S3.php
+++ b/application/controllers/S3.php
@@ -330,7 +330,6 @@ class S3 extends Instance_Controller
       return true;
     }
 
-    $accessLevel = $this->user_model->getAccessLevel("collection", $collection);
-    return $accessLevel >= PERM_ADDASSETS;
+    return $this->user_model->havePermForCollection(PERM_ADDASSETS, $collection->getId());
   }
 }

--- a/application/helpers/elevator_url_helper.php
+++ b/application/helpers/elevator_url_helper.php
@@ -109,8 +109,17 @@ function getFinalURL($url)
 function render_json($source, $status = 200) {
 	$CI =& get_instance();
 	return $CI->output
-        ->set_content_type('application/json')
-        ->set_status_header($status)
-        ->set_output(json_encode($source));
 
+// immediately exit with a JSON response
+function abort_json($data, $status = 400)
+{
+	$CI = &get_instance();
+	$CI->output
+		->set_content_type('application/json')
+		->set_status_header($status)
+		->set_output(json_encode($data));
+
+	// Force CodeIgniter to send the response and exit
+	$CI->output->_display();
+	exit();
 }

--- a/application/helpers/elevator_url_helper.php
+++ b/application/helpers/elevator_url_helper.php
@@ -106,9 +106,15 @@ function getFinalURL($url)
 }
 
 
-function render_json($source, $status = 200) {
-	$CI =& get_instance();
+function render_json($source, $status = 200)
+{
+	$CI = &get_instance();
 	return $CI->output
+		->set_content_type('application/json')
+		->set_status_header($status)
+		->set_output(json_encode($source));
+}
+
 
 // immediately exit with a JSON response
 function abort_json($data, $status = 400)

--- a/application/libraries/SimpleValidator.php
+++ b/application/libraries/SimpleValidator.php
@@ -45,6 +45,7 @@ class SimpleValidator
       throw new ValidationException($errors);
     }
 
+    // return only the fields that are defined in the schema
     return array_intersect_key($data, $schema);
   }
 

--- a/application/libraries/SimpleValidator.php
+++ b/application/libraries/SimpleValidator.php
@@ -89,7 +89,7 @@ class SimpleValidator
 
   public static function minLength(int $length): \Closure
   {
-    return fn($v) => is_string($v) && mb_strlen($v) >= $length
+    return fn($v) => !isset($v) || (is_string($v) && mb_strlen($v) >= $length)
       ? true
       : "Must be at least {$length} characters long";
   }

--- a/application/libraries/SimpleValidator.php
+++ b/application/libraries/SimpleValidator.php
@@ -6,6 +6,25 @@ class SimpleValidator
   /**
    * Validates $data against $schema (array of field => closure[])
    * Returns filtered data or throws ValidationException
+   * 
+   * @example
+   * ```php
+   * use SimpleValidator as V;
+   * 
+   * $data = [
+   *  'name' => 'John Doe',
+   *  'age' => 30,
+   * ];
+   * $schema = [
+   *  'name' => [V::required(), V::minLength(3)],
+   *  'age' => [V::required(), V::integer(), V::min(18)],
+   * ];
+   * 
+   * try {
+   *  $validatedData = V::validate($data, $schema);
+   * } catch (ValidationException $e) {
+   *  $errors = $e->getErrors();
+   * }
    */
   public static function validate(array $data, array $schema): array
   {
@@ -27,44 +46,6 @@ class SimpleValidator
     }
 
     return array_intersect_key($data, $schema);
-  }
-
-  // /**
-  //  * Converts a string-based rule array into closure array
-  //  * E.g. ['required', 'min:3'] → [closure(), closure()]
-  //  */
-  public static function rules(array $rules): array
-  {
-    return $rules;
-    // return array_map(function ($rule) {
-    //   if ($rule instanceof \Closure) return $rule;
-
-    //   var_dump($rule);
-
-    //   if (str_contains($rule, ':')) {
-    //     [$name, $param] = explode(':', $rule, 2);
-    //     return self::fromString($name, $param);
-    //   }
-
-    //   return self::fromString($rule);
-    // }, $rules);
-  }
-
-  /**
-   * Maps string rule names to closure factories
-   */
-  private static function fromString(string $rule, $param = null): \Closure
-  {
-    return match ($rule) {
-      'required'    => self::required(),
-      'integer'     => self::integer(),
-      'min'         => self::min((int) $param),
-      'max'         => self::max((int) $param),
-      'regex'       => self::regex($param),
-      'minLength', 'min_length' => self::minLength((int) $param),
-      'array' => self::array(),
-      default       => fn() => "Unknown validation rule: {$rule}"
-    };
   }
 
   // —–––– Validators —––––

--- a/application/libraries/SimpleValidator.php
+++ b/application/libraries/SimpleValidator.php
@@ -1,0 +1,114 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+
+class SimpleValidator
+{
+  /**
+   * Validates $data against $schema (array of field => closure[])
+   * Returns filtered data or throws ValidationException
+   */
+  public static function validate(array $data, array $schema): array
+  {
+    $errors = [];
+
+    foreach ($schema as $field => $checkers) {
+      $value = $data[$field] ?? null;
+
+      foreach ($checkers as $checker) {
+        $result = $checker($value, $data);
+        if ($result !== true) {
+          $errors[$field][] = $result;
+        }
+      }
+    }
+
+    if (!empty($errors)) {
+      throw new ValidationException($errors);
+    }
+
+    return array_intersect_key($data, $schema);
+  }
+
+  // /**
+  //  * Converts a string-based rule array into closure array
+  //  * E.g. ['required', 'min:3'] → [closure(), closure()]
+  //  */
+  public static function rules(array $rules): array
+  {
+    return $rules;
+    // return array_map(function ($rule) {
+    //   if ($rule instanceof \Closure) return $rule;
+
+    //   var_dump($rule);
+
+    //   if (str_contains($rule, ':')) {
+    //     [$name, $param] = explode(':', $rule, 2);
+    //     return self::fromString($name, $param);
+    //   }
+
+    //   return self::fromString($rule);
+    // }, $rules);
+  }
+
+  /**
+   * Maps string rule names to closure factories
+   */
+  private static function fromString(string $rule, $param = null): \Closure
+  {
+    return match ($rule) {
+      'required'    => self::required(),
+      'integer'     => self::integer(),
+      'min'         => self::min((int) $param),
+      'max'         => self::max((int) $param),
+      'regex'       => self::regex($param),
+      'minLength', 'min_length' => self::minLength((int) $param),
+      'array' => self::array(),
+      default       => fn() => "Unknown validation rule: {$rule}"
+    };
+  }
+
+  // —–––– Validators —––––
+
+  public static function required(): \Closure
+  {
+    return fn($v) => (isset($v) && $v !== '') ? true : 'This field is required';
+  }
+
+  public static function integer(): \Closure
+  {
+    return fn($v) => !isset($v) || filter_var($v, FILTER_VALIDATE_INT) !== false ? true : 'Must be an integer';
+  }
+
+  public static function array(): \Closure
+  {
+    return fn($v) => !isset($v) || is_array($v) ? true : 'Must be an array';
+  }
+
+  public static function min(int $min): \Closure
+  {
+    return fn($v) => !isset($v) || (is_numeric($v) && $v >= $min)
+      ? true
+      : "Must be at least {$min}";
+  }
+
+  public static function max(int $max): \Closure
+  {
+    return fn($v) => !isset($v) || (is_numeric($v) && $v <= $max)
+      ? true
+      : "Must not exceed {$max}";
+  }
+
+  public static function regex(string $pattern): \Closure
+  {
+    return fn($v) => !isset($v) || preg_match($pattern, $v)
+      ? true
+      : "Value does not match pattern: {$pattern}";
+  }
+
+  public static function minLength(int $length): \Closure
+  {
+    return fn($v) => is_string($v) && mb_strlen($v) >= $length
+      ? true
+      : "Must be at least {$length} characters long";
+  }
+}

--- a/application/libraries/SimpleValidator.php
+++ b/application/libraries/SimpleValidator.php
@@ -84,7 +84,7 @@ class SimpleValidator
   {
     return fn($v) => !isset($v) || preg_match($pattern, $v)
       ? true
-      : "Value does not match pattern: {$pattern}";
+      : "Invalid format.";
   }
 
   public static function minLength(int $length): \Closure

--- a/application/libraries/ValidationException.php
+++ b/application/libraries/ValidationException.php
@@ -1,0 +1,18 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+
+class ValidationException extends RuntimeException
+{
+  protected array $errors;
+
+  public function __construct(array $errors)
+  {
+    parent::__construct('Validation failed', 422);
+    $this->errors = $errors;
+  }
+
+  public function getErrors(): array
+  {
+    return $this->errors;
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "cocur/background-process": "^0.5.0",
     "google/apiclient": "dev-disableCache-merge-84",
     "php-unoconv/php-unoconv": "dev-master",
-    "aws/aws-sdk-php": "^3.151",
+    "aws/aws-sdk-php": "^3.349",
     "sentry/sdk": "^4.0",
     "vlucas/phpdotenv": "^5.6",
     "packbackbooks/lti-1p3-tool": "dev-upstream-merge-2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "08df96e382eff6d78b01ad96accbf763",
+    "content-hash": "adbaf913f6882d857445928a7a5b221f",
     "packages": [
         {
             "name": "alchemy/binary-driver",
@@ -129,16 +129,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.339.14",
+            "version": "3.349.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "532eb5e502c5b1181456023e41d61445b2c7101d"
+                "reference": "63cc727845f077d17cb94791deb327249e1626ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/532eb5e502c5b1181456023e41d61445b2c7101d",
-                "reference": "532eb5e502c5b1181456023e41d61445b2c7101d",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/63cc727845f077d17cb94791deb327249e1626ce",
+                "reference": "63cc727845f077d17cb94791deb327249e1626ce",
                 "shasum": ""
             },
             "require": {
@@ -220,9 +220,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.339.14"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.349.2"
             },
-            "time": "2025-02-14T19:11:38+00:00"
+            "time": "2025-07-03T18:08:27+00:00"
         },
         {
             "name": "buggedcom/phpvideotoolkit",
@@ -5135,17 +5135,17 @@
     ],
     "minimum-stability": "dev",
     "stability-flags": {
-        "doctrine/dbal": 20,
-        "smalot/pdfparser": 20,
         "buggedcom/phpvideotoolkit": 20,
+        "doctrine/dbal": 20,
         "google/apiclient": 20,
-        "php-unoconv/php-unoconv": 20,
         "packbackbooks/lti-1p3-tool": 20,
-        "pda/pheanstalk": 20
+        "pda/pheanstalk": 20,
+        "php-unoconv/php-unoconv": 20,
+        "smalot/pdfparser": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/docker/postgresQueries
+++ b/docker/postgresQueries
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 INSERT INTO "instances"("id","name","domain","ownerhomepage","amazons3key","s3storagetype","defaultbucket","bucketregion","amazons3secret","googleanalyticskey","introtext","createdat","modifiedat","usecustomheader","usecustomcss","useheaderlogo","usecentralauth","hidevideoaudio","featuredasset","featuredassettext","customheadertext","customfootertext","customheadercss","customheaderimage","allowindexing","showcollectioninsearchresults","showtemplateinsearchresults","showpreviousnextsearchresults","enablehlsstreaming","enableinterstitial","interstitialtext","notes","interfaceversion","defaulttheme","enablethemes","customhomeredirect","maximummorelikethis","defaulttexttruncationheight","availablethemes")
 VALUES
-(1,E'defaultinstance',E'defaultinstance',E'mailto:mcfa0086@umn.edu',E'',E'STANDARD',E'',E'',E'',E'',E'',NULL,E'2024-04-05 17:55:03',0,FALSE,FALSE,TRUE,FALSE,E'575ee4ceba98a87472f3e030',E'This is text about the featured asset.',E'',E'',E'',NULL,FALSE,TRUE,TRUE,TRUE,TRUE,FALSE,E'',E'This is an instance note.',0,E'folwell',TRUE,E'',3,72,E'["folwell", "light"]');
+(1,E'defaultinstance',E'defaultinstance',E'mailto:mcfa0086@umn.edu',E'',E'STANDARD',E'',E'',E'',E'',E'',NULL,E'2024-04-05 17:55:03',0,FALSE,FALSE,TRUE,FALSE,E'',E'',E'',E'',E'',NULL,FALSE,TRUE,TRUE,TRUE,TRUE,FALSE,E'',E'This is an instance note.',0,E'folwell',TRUE,E'',3,72,E'["folwell", "light"]');
 
 INSERT INTO "permissions"("id","name","label","level","createdat","modifiedat")
 VALUES


### PR DESCRIPTION
This complements https://github.com/UMN-LATIS/elevator-ui/pull/305 PR to add support for add/edit assets and adds endpoints for uploading files:

- adds `/s3` endpoint for supporting uppy
- adds a simple validator for validating request data in the S3 controller
- adds `abort_json` method to force CI to return a response and exit immediately (used when validation fails)
- bumps aws sdk version to latest minor
- fixes an issue when using `postgresQueries` to set up local dev environment. Removes the "feature asset" id.
- adds certs and REVISION to gitignore. (I think I needed to do this for local dev, but now I can't remember)