### PR TITLE
update css manifest key for vite@7

### DIFF
--- a/application/views/vueTemplate.php
+++ b/application/views/vueTemplate.php
@@ -11,7 +11,7 @@ if (json_last_error() !== JSON_ERROR_NONE) {
 }
 
 $indexFile = $manifest['src/main.ts']['file'];
-$cssFile = $manifest['src/main.css']['file'];
+$cssFile = $manifest['style.css']['file'];
 
 $customCSSFile = "/assets/instanceAssets/{$this->instance->getId()}.css";
 $customCSSHash = $this->instance->getModifiedAt()->getTimestamp();


### PR DESCRIPTION
This coincides with Vite 7 update in elevator-ui: https://github.com/UMN-LATIS/elevator-ui/pull/310

Vite changed the default css manifest key to `style.css`.