### PR TITLE
update date widget json to return `range` prop

### DIFF
--- a/application/models/widget_contents/Date_contents.php
+++ b/application/models/widget_contents/Date_contents.php
@@ -28,7 +28,7 @@ class Date_contents extends Widget_contents_base {
 				"text" => $this->end["text"],
 				"numeric" => $this->end["numeric"]
 			],
-			"range" => $this->range,
+			"range" => $this->range ?? false,
 			"isPrimary" => $this->isPrimary
 		];
 	}

--- a/application/models/widget_contents/Date_contents.php
+++ b/application/models/widget_contents/Date_contents.php
@@ -18,7 +18,19 @@ class Date_contents extends Widget_contents_base {
 	 * @return [type] [description]
 	 */
 	public function getAsArray($serializeNestedObjects=false) {
-		return ["label"=>$this->label, "start"=>["text"=>$this->start["text"], "numeric"=>$this->start["numeric"]], "end"=>["text"=>$this->end["text"], "numeric"=>$this->end["numeric"]],"isPrimary"=>$this->isPrimary];
+		return [
+			"label" => $this->label,
+			"start" => [
+				"text" => $this->start["text"],
+				"numeric" => $this->start["numeric"]
+			],
+			"end" => [
+				"text" => $this->end["text"],
+				"numeric" => $this->end["numeric"]
+			],
+			"range" => $this->range,
+			"isPrimary" => $this->isPrimary
+		];
 	}
 
 	public function getAsText($serializeNestedObjects=false) {


### PR DESCRIPTION
Return the `range` property with the widget data. This resolves an issue in the new UI where the widget shows in `moment` format even though it's a `range`.

on dev for testing