### PR TITLE
Handle 404 errors with Vue UI support

### DIFF
--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -39,7 +39,7 @@
 */
 
 $route['default_controller'] = "home";
-$route['404_override'] = '';
+$route['404_override'] = 'errorHandler/notFound';
 $route['robots.txt'] = "home/robots";
 $route['Shibboleth.sso/SAML2/POST']  = "Shibboleth/localSPACS";
 

--- a/application/controllers/ErrorHandler.php
+++ b/application/controllers/ErrorHandler.php
@@ -34,6 +34,17 @@ class errorHandler extends Instance_Controller {
 		$this->errorhandler_helper->callError($errorName);
 	}
 
+	public function notFound()
+	{
+		if ($this->isUsingVueUI()) {
+			$this->template->set_template("vueTemplate");
+			$this->template->publish();
+			return;
+		}
+
+		show_404();
+	}
+
 }
 
 /* End of file  */


### PR DESCRIPTION
Routes 404 errors through the error handler controller instead of using the default behavior, allowing the Vue-based UI to render its own 404 page while falling back to the standard 404 for non-Vue instances.