### PR TITLE
create elasticsearch index during boostrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ REVISION
 # Playwright output
 /test-results/
 /playwright-report/
+scripts/elastic_setup.sh

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Elevator can store content in any format, such as images, audio, video, 3D objec
 ### Prerequisites
 
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+- [`gh`](https://cli.github.com/) — GitHub CLI, authenticated with `gh auth login`. Required to fetch the Elasticsearch setup script from the private ansible repo.
 - [`mkcert`](https://github.com/FiloSottile/mkcert) *(optional but recommended)* — generates locally-trusted SSL certs. Without it, bootstrap falls back to a self-signed cert that will show browser warnings.
 
 ### First-time setup
@@ -35,22 +36,14 @@ Elevator can store content in any format, such as images, audio, video, 3D objec
 bash scripts/bootstrap
 ```
 
-The script handles everything: copying `.env`, generating SSL certs, starting Docker, installing PHP and Node dependencies, running the Doctrine schema, seeding the database, and syncing the admin password. It's safe to re-run — steps that are already complete are skipped.
+The script handles everything: copying `.env`, generating SSL certs, starting Docker, installing PHP and Node dependencies, running the Doctrine schema, seeding the database, syncing the admin password, and setting up the Elasticsearch index with the correct mapping. It's safe to re-run — steps that are already complete are skipped.
+
+The Elasticsearch step fetches the canonical index setup script from [ansible-elevator-v2](https://github.com/umn-cla/ansible-elevator-v2) via `gh`, so you'll need the `gh` CLI installed and authenticated (`gh auth login`) with access to that repo.
 
 After the script finishes:
 
 - **App:** `https://localhost/defaultinstance`
 - **Admin:** username `admin`, password is `DEFAULT_ADMIN_PASSWORD` from your `.env` (default: `admin`). To change it, update `DEFAULT_ADMIN_PASSWORD` in `.env` and re-run `./scripts/bootstrap`.
-
-### Set up Elasticsearch indices
-
-After bootstrap, initialise the search indices (this only needs to be done once):
-
-```bash
-docker compose exec php-fpm php index.php beltdrive updateIndexes
-```
-
-> **Tip:** If search isn't working, make sure `ELASTIC_HOST=elasticsearch:9200` (with port) in your `.env`.
 
 ### Multiple worktrees / port conflicts
 
@@ -188,7 +181,26 @@ This typically frees 20–40 GB and clears the error.
 
 ### Elasticsearch not returning results
 
-Make sure your `.env` has `ELASTIC_HOST=elasticsearch:9200` (the `:9200` port suffix is required). Re-run `updateIndexes` after fixing it.
+Make sure your `.env` has `ELASTIC_HOST=elasticsearch:9200` (the `:9200` port suffix is required).
+
+If the index exists but search returns nothing, the index mapping is likely missing or stale. Do a full reset:
+
+```bash
+# Re-fetch the setup script and rebuild the index from scratch
+bash scripts/bootstrap
+```
+
+Or manually, if you want to avoid re-running the full bootstrap:
+
+```bash
+_idx="elevator"  # match ELASTIC_INDEX in .env
+curl -XDELETE "http://localhost:9200/${_idx}_1"
+curl -XDELETE "http://localhost:9200/${_idx}"
+bash scripts/elastic_setup.sh localhost "${_idx}_1" "${_idx}"
+docker compose exec php-fpm php index.php admin reindex
+```
+
+Assets are automatically re-indexed on save, so a full reindex is only needed after a mapping change or bulk data import.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
   reindex-worker:
     image: elevator-php-fpm:latest
     command: php index.php beltdrive updateIndexes
+    restart: unless-stopped
     volumes:
       - ./:/var/www/html
       - ${DOCKER_SCRATCH_DIR}:/scratch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,19 @@ services:
     image: maateen/docker-beanstalkd
     ports:
       - "${BEANSTALKD_PORT:-11300}:11300"
+
+  reindex-worker:
+    image: elevator-php-fpm:latest
+    command: php index.php beltdrive updateIndexes
+    volumes:
+      - ./:/var/www/html
+      - ${DOCKER_SCRATCH_DIR}:/scratch
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - beanstalkd
+      - elasticsearch
+      - postgres
+
   php-fpm:
     image: elevator-php-fpm:latest
     build:

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -126,9 +126,31 @@ fi
 
 # ── Elasticsearch index ───────────────────────────────────────────────────────
 
-info "Creating Elasticsearch index..."
-docker compose exec php-fpm php index.php admin reindex false true
-success "Elasticsearch index created."
+require gh
+
+info "Fetching Elasticsearch setup script from ansible-elevator-v2..."
+gh api repos/umn-cla/ansible-elevator-v2/contents/files/elastic_commands.sh --jq '.content' \
+    | base64 -d > scripts/elastic_setup.sh \
+    || fatal "Could not fetch elastic_commands.sh — make sure you are authenticated with 'gh auth login' and have access to umn-cla/ansible-elevator-v2."
+chmod +x scripts/elastic_setup.sh
+success "Elasticsearch setup script fetched."
+
+_elastic_index=$(grep -E '^ELASTIC_INDEX=' .env 2>/dev/null | cut -d= -f2 | tr -d '"' || true)
+_elastic_index="${_elastic_index:-elevator}"
+_elastic_internal="${_elastic_index}_1"
+
+info "Wiping existing Elasticsearch index (if any)..."
+curl -sf -XDELETE "http://localhost:9200/${_elastic_internal}" > /dev/null 2>&1 || true
+curl -sf -XDELETE "http://localhost:9200/${_elastic_index}" > /dev/null 2>&1 || true
+
+info "Creating Elasticsearch index and applying mapping..."
+bash scripts/elastic_setup.sh localhost "$_elastic_internal" "$_elastic_index" \
+    || fatal "Elasticsearch setup failed — is Elasticsearch running?"
+success "Elasticsearch index and mapping created."
+
+info "Indexing assets into Elasticsearch..."
+docker compose exec php-fpm php index.php admin reindex
+success "Elasticsearch index populated."
 
 # ── Node / Playwright ─────────────────────────────────────────────────────────
 

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -149,7 +149,7 @@ bash scripts/elastic_setup.sh localhost "$_elastic_internal" "$_elastic_index" \
 success "Elasticsearch index and mapping created."
 
 info "Indexing assets into Elasticsearch..."
-docker compose exec php-fpm php index.php admin reindex
+docker compose exec -T php-fpm php index.php admin reindex
 success "Elasticsearch index populated."
 
 # ── Node / Playwright ─────────────────────────────────────────────────────────

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -124,6 +124,12 @@ else
     warn "ENCRYPTION_KEY or DEFAULT_ADMIN_PASSWORD not set in .env — skipping password sync."
 fi
 
+# ── Elasticsearch index ───────────────────────────────────────────────────────
+
+info "Creating Elasticsearch index..."
+docker compose exec php-fpm php index.php admin reindex false true
+success "Elasticsearch index created."
+
 # ── Node / Playwright ─────────────────────────────────────────────────────────
 
 if [[ -f package.json ]]; then

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -139,6 +139,12 @@ _elastic_index=$(grep -E '^ELASTIC_INDEX=' .env 2>/dev/null | cut -d= -f2 | tr -
 _elastic_index="${_elastic_index:-elevator}"
 _elastic_internal="${_elastic_index}_1"
 
+info "Waiting for Elasticsearch to be ready..."
+until curl -sf "http://localhost:9200/_cluster/health" > /dev/null 2>&1; do
+    sleep 2
+done
+success "Elasticsearch is ready."
+
 info "Wiping existing Elasticsearch index (if any)..."
 curl -sf -XDELETE "http://localhost:9200/${_elastic_internal}" > /dev/null 2>&1 || true
 curl -sf -XDELETE "http://localhost:9200/${_elastic_index}" > /dev/null 2>&1 || true


### PR DESCRIPTION
When bootstrapping a fresh setup locally, the first time we attempt to autocomplete, we'll get an 500 error because an elastic search index doesn't exist yet.

This creates it when we run our local dev bootstrap script (`./scripts/bootstrap`).
