### PR TITLE
fix(asset): return 404 for soft-deleted assets 

### DIFF
--- a/application/controllers/Asset.php
+++ b/application/controllers/Asset.php
@@ -78,12 +78,15 @@ class asset extends Instance_Controller {
 
 		$assetModel = new Asset_model;
 		if(!$objectId) {
-			show_404();
+			return $returnJson == "true"
+				? render_json(["error" => "not found"], 404)
+				: show_404();
 		}
 
-		
 		if(!$assetModel->loadAssetById($objectId)) {
-			show_404();
+			return $returnJson == "true"
+				? render_json(["error" => "not found"], 404)
+				: show_404();
 		}
 
 		if($assetModel->assetObject->getDeleted() === true) {
@@ -93,7 +96,9 @@ class asset extends Instance_Controller {
 		}
 
 		if(!$this->collection_model->getCollection($assetModel->getGlobalValue("collectionId"))) {
-			show_404();
+			return $returnJson == "true"
+				? render_json(["error" => "not found"], 404)
+				: show_404();
 		}
 
 		if ($parentObjectId && $parentObjectId != "null" && $parentObjectId != $objectId) {

--- a/application/controllers/Asset.php
+++ b/application/controllers/Asset.php
@@ -33,7 +33,7 @@ class asset extends Instance_Controller {
 			show_404();
 		}
 
-		
+
 		if(!$assetModel->loadAssetById($objectId, $noHydrate = true)) {
 			show_404();
 		}

--- a/application/controllers/Asset.php
+++ b/application/controllers/Asset.php
@@ -38,6 +38,10 @@ class asset extends Instance_Controller {
 			show_404();
 		}
 
+		if($assetModel->assetObject->getDeleted() === true) {
+			show_404();
+		}
+
 		if(!$this->collection_model->getCollection($assetModel->assetObject->getCollectionId())) {
 			show_404();
 		}
@@ -80,6 +84,12 @@ class asset extends Instance_Controller {
 		
 		if(!$assetModel->loadAssetById($objectId)) {
 			show_404();
+		}
+
+		if($assetModel->assetObject->getDeleted() === true) {
+			return $returnJson == "true"
+				? render_json(["error" => "not found"], 404)
+				: show_404();
 		}
 
 		if(!$this->collection_model->getCollection($assetModel->getGlobalValue("collectionId"))) {
@@ -565,7 +575,9 @@ class asset extends Instance_Controller {
 
 	public function getAssetPreview($objectId) {
 		$assetModel = new Asset_model();
-		$assetModel->loadAssetById($objectId);
+		if(!$assetModel->loadAssetById($objectId) || $assetModel->assetObject->getDeleted() === true) {
+			show_404();
+		}
 		$result = $assetModel->getSearchResultEntry();
 		echo json_encode($result);
 	}

--- a/application/controllers/CollectionManager.php
+++ b/application/controllers/CollectionManager.php
@@ -110,6 +110,10 @@ class CollectionManager extends Instance_Controller {
 		$this->doctrine->em->persist($collection);
 		$this->doctrine->em->flush();
 
+		if($this->isJsonRequest()) {
+			return render_json(["id" => $collection->getId(), "title" => $collection->getTitle()], 201);
+		}
+
 		instance_redirect("collectionManager/");
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.54.1",
-        "@types/node": "^22.19.13"
+        "@types/node": "^22.19.13",
+        "dotenv": "^17.3.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -6374,6 +6375,19 @@
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -23152,6 +23166,12 @@
           "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
         }
       }
+    },
+    "dotenv": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "dev": true
     },
     "dunder-proto": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.54.1",
-    "@types/node": "^22.19.13"
+    "@types/node": "^22.19.13",
+    "dotenv": "^17.3.1"
   },
   "dependencies": {
     "@vuepress/plugin-blog": "^1.9.4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
+import { config } from "dotenv";
+
+config(); // load .env into process.env
 
 export default defineConfig({
   testDir: "./tests/api",

--- a/tests/api/assets.spec.ts
+++ b/tests/api/assets.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "@playwright/test";
+import {
+  loginUser,
+  refreshDatabase,
+  baseURL,
+  createTemplate,
+  createCollection,
+  createAsset,
+} from "../helpers";
+
+test.describe("assets", () => {
+  test.beforeAll(() => {
+    refreshDatabase();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const adminPassword = process.env.DEFAULT_ADMIN_PASSWORD;
+    if (!adminPassword) {
+      test.skip(true, "DEFAULT_ADMIN_PASSWORD env var not set");
+      return;
+    }
+    await loginUser(page, process.env.ADMIN_USERNAME ?? "admin", adminPassword);
+  });
+
+  test.afterEach(() => {
+    refreshDatabase();
+  });
+
+  // Regression test for issue #467: deleting an asset and then navigating to
+  // its URL caused a 500 (for assets with uploads) or returned stale data
+  // (bare assets). The fix adds a deleted check in Asset::getAsset() and
+  // Asset::viewAsset() after loadAssetById() succeeds.
+  test("deleted asset returns 404, not 200", async ({ page }) => {
+    const collectionId = await createCollection(page, "Test Collection #467");
+    const template = await createTemplate(page, { name: "Test Template #467" });
+    const assetId = await createAsset(page, template.id, collectionId);
+
+    // Sanity check: asset is accessible before deletion.
+    const beforeDelete = await page.request.get(
+      `${baseURL()}/asset/viewAsset/${assetId}/true`,
+    );
+    expect(beforeDelete.status()).toBe(200);
+
+    // Delete the asset (soft-delete).
+    const deleteRes = await page.request.get(
+      `${baseURL()}/assetmanager/deleteAsset/${assetId}/true`,
+    );
+    expect(deleteRes.status()).toBe(204);
+
+    // getAsset must return 404 for a soft-deleted asset.
+    const getRes = await page.request.get(
+      `${baseURL()}/asset/getAsset/${assetId}`,
+    );
+    expect(getRes.status()).toBe(404);
+
+    // viewAsset must also return 404.
+    const viewRes = await page.request.get(
+      `${baseURL()}/asset/viewAsset/${assetId}/true`,
+    );
+    expect(viewRes.status()).toBe(404);
+  });
+});

--- a/tests/api/collections.spec.ts
+++ b/tests/api/collections.spec.ts
@@ -24,9 +24,9 @@ test.describe("collections", () => {
 
   test("db reset removes created collection", async ({ page }) => {
     // Create a collection via the admin form endpoint.
-    // POST /{instance}/collectionmanager/save — redirects to collectionmanager/ on success.
+    // POST /{instance}/collectionManager/save — redirects to collectionManager/ on success.
     const createResponse = await page.request.post(
-      `${baseURL()}/collectionmanager/save`,
+      `${baseURL()}/collectionManager/save`,
       {
         form: {
           title: "Test Collection (should be reset)",
@@ -45,7 +45,7 @@ test.describe("collections", () => {
 
     // Verify it exists via the admin collection manager page (session-auth HTML).
     const beforeReset = await page.request.get(
-      `${baseURL()}/collectionmanager/`,
+      `${baseURL()}/collectionManager/`,
     );
     expect(await beforeReset.text()).toContain(
       "Test Collection (should be reset)",
@@ -56,7 +56,7 @@ test.describe("collections", () => {
 
     // Verify it is gone.
     const afterReset = await page.request.get(
-      `${baseURL()}/collectionmanager/`,
+      `${baseURL()}/collectionManager/`,
     );
     expect(await afterReset.text()).not.toContain(
       "Test Collection (should be reset)",

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -89,3 +89,69 @@ export async function createTemplate(
 
   return response.json() as Promise<TemplateResponse>;
 }
+
+// POST /{instance}/collectionManager/save
+// Returns the new collection's id and title.
+// Sends Accept: application/json so the endpoint returns JSON instead of redirecting.
+export async function createCollection(
+  page: Page,
+  title = "Test Collection",
+): Promise<number> {
+  const response = await page.request.post(
+    `${baseURL()}/collectionManager/save`,
+    {
+      headers: { Accept: "application/json" },
+      form: {
+        title,
+        bucket: "",
+        bucketRegion: "",
+        S3Key: "",
+        S3Secret: "",
+        showInBrowse: "on",
+        collectionDescription: "",
+        previewImage: "",
+        parent: "0",
+      },
+    },
+  );
+
+  if (!response.ok()) {
+    const body = (await response.json().catch(() => ({}))) as {
+      error?: string;
+    };
+    throw new Error(
+      `createCollection failed (${response.status()}): ${body.error ?? "unknown"}`,
+    );
+  }
+
+  const body = (await response.json()) as { id: number; title: string };
+  return body.id;
+}
+
+// POST /{instance}/assetmanager/submission/true
+// formData is a JSON string containing at minimum templateId and collectionId.
+// Returns the new asset's objectId (a 24-char hex MongoDB-style ID).
+export async function createAsset(
+  page: Page,
+  templateId: number,
+  collectionId: number,
+): Promise<string> {
+  const formData = JSON.stringify({ templateId, collectionId });
+
+  const response = await page.request.post(
+    `${baseURL()}/assetmanager/submission/true`,
+    { form: { formData } },
+  );
+
+  if (!response.ok()) {
+    const body = (await response.json().catch(() => ({}))) as {
+      error?: string;
+    };
+    throw new Error(
+      `createAsset failed (${response.status()}): ${body.error ?? "unknown"}`,
+    );
+  }
+
+  const body = (await response.json()) as { objectId: string; success: boolean };
+  return body.objectId;
+}


### PR DESCRIPTION
## Summary

Soft-deleted assets were still served by the Asset controller — returning stale data or a 500 depending on asset state. This PR adds `getDeleted()` checks so they return 404 instead. Closes UMN-LATIS/elevator-ui#467.

Resolves https://github.com/UMN-LATIS/elevator-ui/issues/467

## The Problem

Navigating to a deleted asset's URL returned either stale widget data (200) or a server error (500) instead of a 404. This affected `getAsset`, `viewAsset`, and `getAssetPreview`.

The response code depends on the asset's data:

- **Status 200** - bare assets (no file uploads) return 200 with empty widget JSON because there's nothing to choke on.
- **Status 500** - assets that previously had file uploads return 500 because a separate bug (described in [#467 comments](https://github.com/UMN-LATIS/elevator-ui/issues/467#issuecomment-2716441547)) corrupts file references into empty arrays when a save is triggered on a deleted asset. The renderer then fails trying to load thumbnails from those empty entries.

Regardless of 200 vs 500, both cases are wrong for the same reason: deleted assets shouldn't be served at all and a 404 should be returned.

### How to see it

See: `assets.spec.ts` > `"deleted asset returns 404, not 200"`

- create an asset
- soft-deletes it
- asserts both `getAsset` and `viewAsset` return 404 instead of 200/500.

The test uses a bare asset (no uploads needed) since the fix is the same regardless of which response code the unfixed code happens to produce.

## The Fix

**The Cause**: `loadAssetById()` queries by `assetId` without filtering on the `deleted` flag. Soft-deleted records load successfully and flow through the entire render pipeline unchecked.

Add a `getDeleted() === true` guard after `loadAssetById()` in each of the three controller methods that serve assets to users. The check lives at the controller level, rather than changing the shared query (which could affect admin/recovery flows).

## Other Notables

- `getAssetPreview` also had no `loadAssetById` failure check and so would fatal error on an invalid ID. This is fixed alongside the deleted check.
- The collections test helper used lowercase `collectionmanager` in URLs. The router's `ucfirst()` maps this to `Collectionmanager.php`, which doesn't match `CollectionManager.php` on case-sensitive filesystems (Docker/Linux). This should probably be fixed, but for now we updated the test helper url to `CollectionManager` as a workaround.
- The separate empty-array JSON corruption bug (a save triggered on a deleted asset overwrites file references with empty arrays) is described in [#467 comments](https://github.com/UMN-LATIS/elevator-ui/issues/467#issuecomment-2716441547) is not addressed here.
