### PR TITLE
add endpoints for handling asset restoration after delete  for new ui

### DIFF
--- a/application/controllers/Asset.php
+++ b/application/controllers/Asset.php
@@ -51,16 +51,22 @@ class asset extends Instance_Controller {
 			if (!$isJson) {
 				return show_404();
 			}
-			// if user can add assets, we want to return a 410 with the deleted
-			// status so that the UI can offer the option to restore
-			return $this->accessLevel >= PERM_ADDASSETS
-				? render_json([
+
+			$canRestore = $this->accessLevel >= PERM_ADDASSETS;
+			if (!$canRestore) {
+				return abort_json(["error" => "not found"], 404);
+			}
+
+			// if user can restore, send a 410 with some info about the
+			// deleted asset so the frontend can offer restore options.
+			// set cache-control to no-store to prevent aggressive browsercaching
+			// of deleted status, which could interfere with restore/undelete actions.
+			return render_json([
 					'error' => 'deleted',
 					'objectId' => $objectId,
 					'deletedAt' => $assetModel->assetObject->getDeletedAt()?->format('c'),
 					'deletedBy' => $assetModel->assetObject->getDeletedBy(),
-				], 410)
-				: render_json(["error" => "not found"], 404);
+				], 410, ['Cache-Control' => 'no-store']);
 		}
 
 		if($this->accessLevel == PERM_NOPERM) {
@@ -146,17 +152,25 @@ class asset extends Instance_Controller {
 		}
 
 		if ($assetModel->assetObject->getDeleted()) {
-			if ($returnJson == "true" && $this->accessLevel >= PERM_ADDASSETS) {
-				return render_json([
+			if ($returnJson != "true") {
+				return show_404();
+			}
+
+			$canRestore = $this->accessLevel >= PERM_ADDASSETS;
+			if (!$canRestore) {
+				return abort_json(["error" => "not found"], 404);
+			}
+
+			// if user can restore, send a 410 with some info about the
+			// deleted asset so the frontend can offer restore options.
+			// set cache-control to no-store to prevent aggressive browser caching
+			// of deleted status, which could interfere with restore/undelete actions.
+			return render_json([
 					'error' => 'deleted',
 					'objectId' => $objectId,
 					'deletedAt' => $assetModel->assetObject->getDeletedAt()?->format('c'),
 					'deletedBy' => $assetModel->assetObject->getDeletedBy(),
-				], 410);
-			}
-			return $returnJson == "true"
-				? render_json(["error" => "not found"], 404)
-				: show_404();
+				], 410, ['Cache-Control' => 'no-store']);
 		}
 
 		if($this->accessLevel == PERM_NOPERM) {

--- a/application/controllers/Asset.php
+++ b/application/controllers/Asset.php
@@ -28,9 +28,13 @@ class asset extends Instance_Controller {
 	}
 
 	function getAsset($objectId) {
+		$isJson = $this->isJsonRequest();
+
 		$assetModel = new Asset_model;
 		if(!$objectId) {
-			show_404();
+			return $isJson
+				? render_json(["error" => "not found"], 404)
+				: show_404();
 		}
 
 
@@ -38,15 +42,26 @@ class asset extends Instance_Controller {
 			show_404();
 		}
 
-		if($assetModel->assetObject->getDeleted() === true) {
-			show_404();
-		}
-
 		if(!$this->collection_model->getCollection($assetModel->assetObject->getCollectionId())) {
 			show_404();
 		}
-		
 		$this->accessLevel = $this->user_model->getAccessLevel("asset", $assetModel);
+
+		if ($assetModel->assetObject->getDeleted()) {
+			if (!$isJson) {
+				return show_404();
+			}
+			// if user can add assets, we want to return a 410 with the deleted
+			// status so that the UI can offer the option to restore
+			return $this->accessLevel >= PERM_ADDASSETS
+				? render_json([
+					'error' => 'deleted',
+					'objectId' => $objectId,
+					'deletedAt' => $assetModel->assetObject->getDeletedAt()?->format('c'),
+					'deletedBy' => $assetModel->assetObject->getDeletedBy(),
+				], 410)
+				: render_json(["error" => "not found"], 404);
+		}
 
 		if($this->accessLevel == PERM_NOPERM) {
 			$this->errorhandler_helper->callJsonError("noPermission");
@@ -84,12 +99,6 @@ class asset extends Instance_Controller {
 		}
 
 		if(!$assetModel->loadAssetById($objectId)) {
-			return $returnJson == "true"
-				? render_json(["error" => "not found"], 404)
-				: show_404();
-		}
-
-		if($assetModel->assetObject->getDeleted() === true) {
 			return $returnJson == "true"
 				? render_json(["error" => "not found"], 404)
 				: show_404();
@@ -134,6 +143,20 @@ class asset extends Instance_Controller {
 
 		if($this->instance->getFeaturedAsset() && $this->instance->getFeaturedAsset() == $objectId) {
 			$this->accessLevel = PERM_SEARCH;
+		}
+
+		if ($assetModel->assetObject->getDeleted()) {
+			if ($returnJson == "true" && $this->accessLevel >= PERM_ADDASSETS) {
+				return render_json([
+					'error' => 'deleted',
+					'objectId' => $objectId,
+					'deletedAt' => $assetModel->assetObject->getDeletedAt()?->format('c'),
+					'deletedBy' => $assetModel->assetObject->getDeletedBy(),
+				], 410);
+			}
+			return $returnJson == "true"
+				? render_json(["error" => "not found"], 404)
+				: show_404();
 		}
 
 		if($this->accessLevel == PERM_NOPERM) {

--- a/application/controllers/AssetManager.php
+++ b/application/controllers/AssetManager.php
@@ -177,10 +177,20 @@ class AssetManager extends Admin_Controller {
 	// Used for restoring an asset state from our history table.  We copy it out of the history and save it with the
 	// existing object id
 	function restoreAsset($objectId) {
+		$isJson = $this->isJsonRequest();
+
+		if (!$this->isCurrentUserAuthed()) {
+			return $isJson
+				? abort_json(['error' => 'Unauthorized'], 401)
+				: $this->errorhandler_helper->callError("noPermission");
+		}
+
 		$accessLevel = max($this->user_model->getAccessLevel("instance", $this->instance), $this->user_model->getMaxCollectionPermission());
 
 		if ($accessLevel < PERM_ADDASSETS) {
-			$this->errorhandler_helper->callError("noPermission");
+			return $isJson
+				? render_json(['error' => 'No permission'], 403)
+				: $this->errorhandler_helper->callError("noPermission");
 		}
 
 		$asset = new Asset_model();
@@ -196,25 +206,55 @@ class AssetManager extends Admin_Controller {
 			$assetArray[] = $tempAsset;
 		}
 
+		if ($isJson) {
+			$result = array_map(fn($a) => [
+				'indexId' => $a->getIndexId(),
+				'modifiedDate' => $a->getGlobalValue("modified"),
+			], $assetArray);
+			return render_json($result);
+		}
+
 		$this->template->content->view('assetManager/restore', ['assetArray' => $assetArray]);
 		$this->template->publish();
 	}
 
 	function restore($objectId) {
+		$isJson = $this->isJsonRequest();
+
+		if (!$this->isCurrentUserAuthed()) {
+			return $isJson
+				? abort_json(['error' => 'Unauthorized'], 401)
+				: $this->errorhandler_helper->callError("noPermission");
+		}
 
 		$accessLevel = max($this->user_model->getAccessLevel("instance", $this->instance), $this->user_model->getMaxCollectionPermission());
 
 		if ($accessLevel < PERM_ADDASSETS) {
-			$this->errorhandler_helper->callError("noPermission");
+			return $isJson
+				? render_json(['error' => 'No permission'], 403)
+				: $this->errorhandler_helper->callError("noPermission");
 		}
 
 		$restoreObject = $this->internalRestore($objectId);
+
+		if ($restoreObject === false) {
+			return $isJson
+				? render_json(['error' => 'Revision not found'], 404)
+				: $this->errorhandler_helper->callError("noPermission");
+		}
+
+		if ($isJson) {
+			return render_json(['objectId' => $restoreObject]);
+		}
 
 		instance_redirect("asset/viewAsset/" . $restoreObject);
 	}
 
 	private function internalRestore(string $objectId, bool $createCheckpoint = true) {
 		$restoreObject = $this->doctrine->em->find("Entity\Asset", $objectId);
+		if (!$restoreObject) {
+			return false;
+		}
 		$currentParent = $restoreObject->getRevisionSource();
 		if (!$currentParent) {
 			return false;
@@ -306,6 +346,10 @@ class AssetManager extends Admin_Controller {
 	}
 
 	public function undeleteAsset($assetId) {
+		if ($this->input->method() !== 'post') {
+			return abort_json(['error' => 'Method not allowed'], 405);
+		}
+
 		if (!$this->isCurrentUserAuthed()) {
 			return abort_json(['error' => 'Unauthorized'], 401);
 		}

--- a/application/controllers/AssetManager.php
+++ b/application/controllers/AssetManager.php
@@ -288,14 +288,15 @@ class AssetManager extends Admin_Controller {
 
 		$result = array_map(function ($asset) {
 			$this->asset_model->loadAssetFromRecord($asset, true);
-			$title = $this->asset_model->getAssetTitle(true);
+			$resultCache = $this->asset_model->getSearchResultEntry();
 			return [
-				'objectId' => $asset->getAssetId(),
-				'title' => $title,
-				'templateId' => $asset->getTemplateId(),
+				'objectId' => $this->asset_model->getObjectId(),
+				'title' => $resultCache['title'] ?? "",
+				'readyForDisplay' => $this->asset_model->getGlobalValue("readyForDisplay"),
+				'templateId' => $this->asset_model->getGlobalValue("templateId"),
+				'modifiedDate' => $this->asset_model->getGlobalValue("modified"),
 				'deletedAt' => $asset->getDeletedAt()?->format('c'),
 				'deletedBy' => $asset->getDeletedBy(),
-				'modifiedDate' => $asset->getModifiedAt()?->format('c'),
 			];
 		}, $assets);
 

--- a/application/controllers/AssetManager.php
+++ b/application/controllers/AssetManager.php
@@ -574,11 +574,10 @@ class AssetManager extends Admin_Controller {
 			return $this->template->publish('vueTemplate');
 		}
 
-		if (!isset($this->instance) || !$this->user_model->userLoaded) {
-			if ($returnJson) {
-				return render_json(["error" => "No permission"], 403);
-			}
-			instance_redirect("errorHandler/error/noPermission");
+		if (!isset($this->instance) || !$this->isCurrentUserAuthed()) {
+			return $returnJson
+				? abort_json(['error' => 'Unauthorized'], 401)
+				: $this->errorhandler_helper->callError("noPermission");
 		}
 
 		$qb = $this->doctrine->em->createQueryBuilder();

--- a/application/controllers/AssetManager.php
+++ b/application/controllers/AssetManager.php
@@ -260,6 +260,48 @@ class AssetManager extends Admin_Controller {
 		return $restoreObject->getAssetId();
 	}
 
+	public function deletedAssets() {
+		$isJson = $this->isJsonRequest();
+
+		if (!$this->isCurrentUserAuthed()) {
+			return $isJson
+				? abort_json(['error' => 'Unauthorized'], 401)
+				: $this->errorhandler_helper->callError("noPermission");
+		}
+
+		$accessLevel = max($this->user_model->getAccessLevel("instance", $this->instance), $this->user_model->getMaxCollectionPermission());
+
+		if ($accessLevel < PERM_ADDASSETS) {
+			return $isJson
+				? render_json(['error' => 'No permission'], 403)
+				: $this->errorhandler_helper->callError("noPermission");
+		}
+
+		$qb = $this->doctrine->em->createQueryBuilder();
+		$assets = $qb->from("Entity\Asset", 'a')
+			->select("a")
+			->where("a.deleted = true")
+			->andWhere("a.assetId IS NOT NULL")
+			->orderBy("a.modifiedAt", "DESC")
+			->getQuery()
+			->execute();
+
+		$result = array_map(function ($asset) {
+			$this->asset_model->loadAssetFromRecord($asset, true);
+			$title = $this->asset_model->getAssetTitle(true);
+			return [
+				'objectId' => $asset->getAssetId(),
+				'title' => $title,
+				'templateId' => $asset->getTemplateId(),
+				'deletedAt' => $asset->getDeletedAt()?->format('c'),
+				'deletedBy' => $asset->getDeletedBy(),
+				'modifiedDate' => $asset->getModifiedAt()?->format('c'),
+			];
+		}, $assets);
+
+		return render_json($result);
+	}
+
 	// save an asset
 	public function submission($returnJson = false) {
 

--- a/application/controllers/AssetManager.php
+++ b/application/controllers/AssetManager.php
@@ -282,6 +282,8 @@ class AssetManager extends Admin_Controller {
 			->select("a")
 			->where("a.deleted = true")
 			->andWhere("a.assetId IS NOT NULL")
+			->andWhere("a.deletedBy = :userId")
+			->setParameter(":userId", (int)$this->user_model->userId)
 			->orderBy("a.modifiedAt", "DESC")
 			->getQuery()
 			->execute();

--- a/application/controllers/AssetManager.php
+++ b/application/controllers/AssetManager.php
@@ -303,6 +303,44 @@ class AssetManager extends Admin_Controller {
 		return render_json($result);
 	}
 
+	public function undeleteAsset($assetId) {
+		if (!$this->isCurrentUserAuthed()) {
+			return abort_json(['error' => 'Unauthorized'], 401);
+		}
+
+		$accessLevel = max($this->user_model->getAccessLevel("instance", $this->instance), $this->user_model->getMaxCollectionPermission());
+
+		if ($accessLevel < PERM_ADDASSETS) {
+			return render_json(['error' => 'No permission'], 403);
+		}
+
+		$qb = $this->doctrine->em->createQueryBuilder();
+		$asset = $qb->from("Entity\Asset", 'a')
+			->select("a")
+			->where("a.assetId = :assetId")
+			->andWhere("a.deleted = true")
+			->setParameter("assetId", $assetId)
+			->setMaxResults(1)
+			->getQuery()
+			->getOneOrNullResult();
+
+		if (!$asset) {
+			return render_json(['error' => 'Asset not found'], 404);
+		}
+
+		$asset->setDeleted(false);
+		$asset->setDeletedBy(null);
+		$asset->setDeletedAt(null);
+		$this->doctrine->em->flush();
+
+		$assetModel = new Asset_model();
+		$assetModel->loadAssetById($assetId);
+		$this->load->model("search_model");
+		$this->search_model->addOrUpdate($assetModel);
+
+		return render_json(['objectId' => $assetId]);
+	}
+
 	// save an asset
 	public function submission($returnJson = false) {
 

--- a/application/controllers/AssetManager.php
+++ b/application/controllers/AssetManager.php
@@ -294,21 +294,63 @@ class AssetManager extends Admin_Controller {
 			->getQuery();
 		$p = $q->execute();
 
+		$this->undeleteFileHandlers($restoreObject);
 		$this->doctrine->em->flush();
+
 		$assetObject = new Asset_model;
 		$assetObject->loadAssetById($restoreObject->getAssetId());
-		$files = $assetObject->getAllWithinAsset("Upload");
-		foreach ($files as $file) {
-			foreach ($file->fieldContentsArray as $entry) {
-				if ($entry->fileHandler && $entry->fileHandler->deleted == true) {
-					$entry->fileHandler->regenerate = true;
-					$entry->fileHandler->undeleteFile();
+		$this->queueUploadRegeneration($assetObject);
+		$assetObject->save(true, false, false);
+		return $restoreObject->getAssetId();
+	}
+
+	/**
+	 * Extract file IDs from an asset's widget JSON and undelete only the
+	 * FileHandler records still referenced by the widget data. Handlers
+	 * the user removed before deletion stay deleted.
+	 *
+	 * Must be called BEFORE loadAssetById, because getHandledObject
+	 * filters out deleted handlers.
+	 */
+	private function undeleteFileHandlers(\Entity\Asset $asset): void {
+		$activeFileIds = [];
+		$widgets = $asset->getWidgets();
+		if (!is_array($widgets)) return;
+
+		foreach ($widgets as $widget) {
+			if (!is_array($widget)) continue;
+			foreach ($widget as $entry) {
+				if (isset($entry['fileId'])) {
+					$activeFileIds[] = $entry['fileId'];
 				}
 			}
 		}
 
-		$assetObject->save(true, false, false);
-		return $restoreObject->getAssetId();
+		if (empty($activeFileIds)) return;
+
+		$deletedHandlers = $this->doctrine->em->getRepository('Entity\FileHandler')
+			->findBy(['fileObjectId' => $activeFileIds, 'deleted' => true]);
+
+		foreach ($deletedHandlers as $handler) {
+			$handler->setDeleted(false);
+		}
+	}
+
+	/**
+	 * Mark all upload file handlers on the asset for derivative regeneration.
+	 * The actual regeneration happens asynchronously via background jobs
+	 * when the file handler is saved.
+	 */
+	private function queueUploadRegeneration(Asset_model $assetModel): void {
+		$files = $assetModel->getAllWithinAsset("Upload");
+		foreach ($files as $file) {
+			foreach ($file->fieldContentsArray as $entry) {
+				if ($entry->fileHandler) {
+					$entry->fileHandler->regenerate = true;
+					$entry->fileHandler->save();
+				}
+			}
+		}
 	}
 
 	public function deletedAssets() {
@@ -390,21 +432,13 @@ class AssetManager extends Admin_Controller {
 		$asset->setDeleted(false);
 		$asset->setDeletedBy(null);
 		$asset->setDeletedAt(null);
+
+		$this->undeleteFileHandlers($asset);
 		$this->doctrine->em->flush();
 
 		$assetModel = new Asset_model();
 		$assetModel->loadAssetById($assetId);
-
-		$files = $assetModel->getAllWithinAsset("Upload");
-		foreach ($files as $file) {
-			foreach ($file->fieldContentsArray as $entry) {
-				if ($entry->fileHandler && $entry->fileHandler->deleted == true) {
-					$entry->fileHandler->regenerate = true;
-					$entry->fileHandler->undeleteFile();
-				}
-			}
-		}
-
+		$this->queueUploadRegeneration($assetModel);
 		$assetModel->save(true, false, false);
 
 		return render_json(['objectId' => $assetId]);

--- a/application/controllers/AssetManager.php
+++ b/application/controllers/AssetManager.php
@@ -11,6 +11,12 @@ class AssetManager extends Admin_Controller {
 	public function __construct() {
 		parent::__construct();
 
+		$this->load->model("asset_model");
+
+		if ($this->isJsonRequest()) {
+			return;
+		}
+
 		$this->template->javascript->add("//maps.google.com/maps/api/js?key=" . $this->config->item("googleApi") . "&sensor=false");
 		$jsLoadArray = ["handlebars-v1.1.2", "formSubmission", "serializeForm", "interWindow", "mapWidget", "dateWidget", "mule2", "uploadWidget", "multiselectWidget", "parsley", "bootstrap-datepicker", "bootstrap-tagsinput", "typeahead.jquery", "assetAutocompleter"];
 		$this->template->loadJavascript($jsLoadArray);
@@ -20,8 +26,6 @@ class AssetManager extends Admin_Controller {
 		$cssLoadArray = ["datepicker", "bootstrap-tagsinput"];
 		$this->template->loadCSS($cssLoadArray);
 		$this->template->javascript->add("assets/tinymce/tinymce.min.js");
-
-		$this->load->model("asset_model");
 	}
 
 	public function addAssetModal() {
@@ -194,7 +198,11 @@ class AssetManager extends Admin_Controller {
 		}
 
 		$asset = new Asset_model();
-		$asset->loadAssetById($objectId);
+		if (!$asset->loadAssetById($objectId)) {
+			return $isJson
+				? render_json(['error' => 'Asset not found'], 404)
+				: $this->errorhandler_helper->callError("unknownAsset");
+		}
 
 		$entries = $asset->assetObject->getRevisions();
 
@@ -207,10 +215,13 @@ class AssetManager extends Admin_Controller {
 		}
 
 		if ($isJson) {
-			$result = array_map(fn($a) => [
-				'indexId' => $a->getIndexId(),
-				'modifiedDate' => $a->getGlobalValue("modified"),
-			], $assetArray);
+			$result = array_map(function ($a) {
+				$modified = $a->getGlobalValue("modified");
+				return [
+					'indexId' => $a->getIndexId(),
+					'modifiedDate' => $modified instanceof \DateTime ? $modified->format('c') : $modified,
+				];
+			}, $assetArray);
 			return render_json($result);
 		}
 
@@ -240,7 +251,7 @@ class AssetManager extends Admin_Controller {
 		if ($restoreObject === false) {
 			return $isJson
 				? render_json(['error' => 'Revision not found'], 404)
-				: $this->errorhandler_helper->callError("noPermission");
+				: $this->errorhandler_helper->callError("unknownAsset");
 		}
 
 		if ($isJson) {
@@ -289,7 +300,7 @@ class AssetManager extends Admin_Controller {
 		$files = $assetObject->getAllWithinAsset("Upload");
 		foreach ($files as $file) {
 			foreach ($file->fieldContentsArray as $entry) {
-				if ($entry->fileHandler->deleted == true) {
+				if ($entry->fileHandler && $entry->fileHandler->deleted == true) {
 					$entry->fileHandler->regenerate = true;
 					$entry->fileHandler->undeleteFile();
 				}
@@ -325,18 +336,20 @@ class AssetManager extends Admin_Controller {
 			->andWhere("a.deletedBy = :userId")
 			->setParameter(":userId", (int)$this->user_model->userId)
 			->orderBy("a.modifiedAt", "DESC")
+			->setMaxResults(200)
 			->getQuery()
 			->execute();
 
 		$result = array_map(function ($asset) {
 			$this->asset_model->loadAssetFromRecord($asset, true);
 			$resultCache = $this->asset_model->getSearchResultEntry();
+			$modifiedDate = $this->asset_model->getGlobalValue("modified");
 			return [
 				'objectId' => $this->asset_model->getObjectId(),
 				'title' => $resultCache['title'] ?? "",
 				'readyForDisplay' => $this->asset_model->getGlobalValue("readyForDisplay"),
 				'templateId' => $this->asset_model->getGlobalValue("templateId"),
-				'modifiedDate' => $this->asset_model->getGlobalValue("modified"),
+				'modifiedDate' => $modifiedDate instanceof \DateTime ? $modifiedDate->format('c') : $modifiedDate,
 				'deletedAt' => $asset->getDeletedAt()?->format('c'),
 				'deletedBy' => $asset->getDeletedBy(),
 			];
@@ -381,8 +394,18 @@ class AssetManager extends Admin_Controller {
 
 		$assetModel = new Asset_model();
 		$assetModel->loadAssetById($assetId);
-		$this->load->model("search_model");
-		$this->search_model->addOrUpdate($assetModel);
+
+		$files = $assetModel->getAllWithinAsset("Upload");
+		foreach ($files as $file) {
+			foreach ($file->fieldContentsArray as $entry) {
+				if ($entry->fileHandler && $entry->fileHandler->deleted == true) {
+					$entry->fileHandler->regenerate = true;
+					$entry->fileHandler->undeleteFile();
+				}
+			}
+		}
+
+		$assetModel->save(true, false, false);
 
 		return render_json(['objectId' => $assetId]);
 	}

--- a/application/controllers/AssetManager.php
+++ b/application/controllers/AssetManager.php
@@ -294,60 +294,54 @@ class AssetManager extends Admin_Controller {
 			->getQuery();
 		$p = $q->execute();
 
-		$this->undeleteFileHandlers($restoreObject);
 		$this->doctrine->em->flush();
 
 		$assetObject = new Asset_model;
 		$assetObject->loadAssetById($restoreObject->getAssetId());
-		$this->queueUploadRegeneration($assetObject);
+		$this->restoreUploadHandlers($assetObject);
 		$assetObject->save(true, false, false);
 		return $restoreObject->getAssetId();
 	}
 
-	/**
-	 * Extract file IDs from an asset's widget JSON and undelete only the
-	 * FileHandler records still referenced by the widget data. Handlers
-	 * the user removed before deletion stay deleted.
-	 *
-	 * Must be called BEFORE loadAssetById, because getHandledObject
-	 * filters out deleted handlers.
-	 */
-	private function undeleteFileHandlers(\Entity\Asset $asset): void {
-		$activeFileIds = [];
-		$widgets = $asset->getWidgets();
-		if (!is_array($widgets)) return;
 
-		foreach ($widgets as $widget) {
-			if (!is_array($widget)) continue;
-			foreach ($widget as $entry) {
-				if (isset($entry['fileId'])) {
-					$activeFileIds[] = $entry['fileId'];
+	/**
+	 * Undelete file handlers referenced by Upload widgets, then mark them
+	 * for derivative regeneration.
+	 */
+	private function restoreUploadHandlers(Asset_model $assetModel): void {
+		$files = $assetModel->getAllWithinAsset("Upload");
+
+		$fileIds = [];
+		foreach ($files as $file) {
+			foreach ($file->fieldContentsArray as $entry) {
+				if ($entry->fileId) {
+					$fileIds[] = $entry->fileId;
 				}
 			}
 		}
 
-		if (empty($activeFileIds)) return;
+		if (empty($fileIds)) {
+			return;
+		}
 
 		$deletedHandlers = $this->doctrine->em->getRepository('Entity\FileHandler')
-			->findBy(['fileObjectId' => $activeFileIds, 'deleted' => true]);
+			->findBy(['fileObjectId' => $fileIds, 'deleted' => true]);
 
 		foreach ($deletedHandlers as $handler) {
 			$handler->setDeleted(false);
 		}
-	}
 
-	/**
-	 * Mark all upload file handlers on the asset for derivative regeneration.
-	 * The actual regeneration happens asynchronously via background jobs
-	 * when the file handler is saved.
-	 */
-	private function queueUploadRegeneration(Asset_model $assetModel): void {
-		$files = $assetModel->getAllWithinAsset("Upload");
+		// flush here so delete status is written to db
+		$this->doctrine->em->flush();
+
+		// getFileHandler() queries the DB for non-deleted handlers,
+		// so the flush above must happen first
 		foreach ($files as $file) {
 			foreach ($file->fieldContentsArray as $entry) {
-				if ($entry->fileHandler) {
-					$entry->fileHandler->regenerate = true;
-					$entry->fileHandler->save();
+				$fileHandler = $entry->getFileHandler();
+				if ($fileHandler) {
+					$fileHandler->regenerate = true;
+					$fileHandler->save();
 				}
 			}
 		}
@@ -433,12 +427,11 @@ class AssetManager extends Admin_Controller {
 		$asset->setDeletedBy(null);
 		$asset->setDeletedAt(null);
 
-		$this->undeleteFileHandlers($asset);
 		$this->doctrine->em->flush();
 
 		$assetModel = new Asset_model();
 		$assetModel->loadAssetById($assetId);
-		$this->queueUploadRegeneration($assetModel);
+		$this->restoreUploadHandlers($assetModel);
 		$assetModel->save(true, false, false);
 
 		return render_json(['objectId' => $assetId]);

--- a/application/controllers/FileManager.php
+++ b/application/controllers/FileManager.php
@@ -446,18 +446,21 @@ class FileManager extends Instance_Controller {
 	}
 
 	function getMetadataForObject($fileId) {
+		$isJson = $this->isJsonRequest();
 
 		$fileHandler = $this->filehandler_router->getHandlerForObject($fileId);
-		$fileHandler->loadByObjectId($fileId);
-		if(!($fileHandler)) {
-			instance_redirect("errorHandler/error/unknownFile");
-			return;
+		if(!$fileHandler) {
+			return $isJson
+				? render_json(["error" => "unknownFile"], 404)
+				: instance_redirect("errorHandler/error/unknownFile");
 		}
+		$fileHandler->loadByObjectId($fileId);
 
 		if(!$this->asset_model->loadAssetById($fileHandler->parentObjectId)) {
 			$this->logging->logError("getOriginal", "could not load asset from fileHandler" . $fileId);
-			instance_redirect("errorHandler/error/unknownFile");
-			return;
+			return $isJson
+				? render_json(["error" => "unknownFile"], 404)
+				: instance_redirect("errorHandler/error/unknownFile");
 		}
 
 		$accessLevel = $this->user_model->getAccessLevel("asset", $this->asset_model);
@@ -465,7 +468,9 @@ class FileManager extends Instance_Controller {
 		$requiredAccessLevel = PERM_SEARCH;
 
 		if($accessLevel < $requiredAccessLevel) {
-			instance_redirect("/errorHandler/error/noPermission");
+			return $isJson
+				? render_json(["error" => "noPermission"], 403)
+				: instance_redirect("/errorHandler/error/noPermission");
 		}
 
 		$metadata = $fileHandler->sourceFile->metadata;

--- a/application/helpers/elevator_url_helper.php
+++ b/application/helpers/elevator_url_helper.php
@@ -112,13 +112,16 @@ function getFinalURL($url)
 }
 
 
-function render_json($source, $status = 200)
+function render_json($source, $status = 200, $headers = [])
 {
 	$CI = &get_instance();
-	return $CI->output
+	$output = $CI->output
 		->set_content_type('application/json')
-		->set_status_header($status)
-		->set_output(json_encode($source));
+		->set_status_header($status);
+	foreach ($headers as $key => $value) {
+		$output->set_header("$key: $value");
+	}
+	return $output->set_output(json_encode($source));
 }
 
 

--- a/application/models/filehandlers/Filehandlerbase.php
+++ b/application/models/filehandlers/Filehandlerbase.php
@@ -711,7 +711,7 @@ class FileHandlerBase extends CI_Model {
 	}
 
 	function undeleteFile() {
-		$this->deleted = true;
+		$this->deleted = false;
 		$this->save();
 		return true;
 	}

--- a/tests/api/assets.spec.ts
+++ b/tests/api/assets.spec.ts
@@ -43,7 +43,7 @@ test.describe("assets", () => {
 
     // Delete the asset (soft-delete).
     const deleteRes = await page.request.get(
-      `${baseURL()}/assetmanager/deleteAsset/${assetId}/true`,
+      `${baseURL()}/assetManager/deleteAsset/${assetId}/true`,
     );
     expect(deleteRes.status()).toBe(204);
 
@@ -59,6 +59,53 @@ test.describe("assets", () => {
     );
     expect(viewRes.status()).toBe(404);
   });
+
+  test.describe("restoreAsset (list revisions) JSON", () => {
+    test("returns 401 when not authenticated", async ({ browser }) => {
+      // Fresh context with no session cookie.
+      const ctx = await browser.newContext();
+      const req = ctx.request;
+      const res = await req.get(
+        `${baseURL()}/assetManager/restoreAsset/000000000000000000000000`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(res.status()).toBe(401);
+      const body = await res.json();
+      expect(body).toHaveProperty("error");
+      await ctx.close();
+    });
+
+    test("returns revision list as JSON", async ({ page }) => {
+      const collectionId = await createCollection(page, "Restore Test Collection");
+      const template = await createTemplate(page, {
+        name: "Restore Test Template",
+      });
+      const assetId = await createAsset(page, template.id, collectionId);
+
+      // Re-submit the asset to create a revision.
+      await page.request.post(`${baseURL()}/assetManager/submission/true`, {
+        form: {
+          formData: JSON.stringify({
+            objectId: assetId,
+            templateId: template.id,
+            collectionId,
+          }),
+        },
+      });
+
+      const res = await page.request.get(
+        `${baseURL()}/assetManager/restoreAsset/${assetId}`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+      expect(Array.isArray(body)).toBe(true);
+      expect(body.length).toBeGreaterThan(0);
+      expect(body[0]).toHaveProperty("indexId");
+      expect(body[0]).toHaveProperty("modifiedDate");
+    });
+  });
+
   test.describe("deletedAssets", () => {
     test("returns 401 when not authenticated", async ({ browser }) => {
       const ctx = await browser.newContext();
@@ -109,10 +156,153 @@ test.describe("assets", () => {
       expect(body.length).toBeGreaterThan(0);
       expect(body[0]).toHaveProperty("objectId");
       expect(body[0]).toHaveProperty("title");
+      expect(body[0]).toHaveProperty("readyForDisplay");
       expect(body[0]).toHaveProperty("templateId");
+      expect(body[0]).toHaveProperty("modifiedDate");
       expect(body[0]).toHaveProperty("deletedAt");
       expect(body[0]).toHaveProperty("deletedBy");
-      expect(body[0]).toHaveProperty("modifiedDate");
+    });
+  });
+
+  test.describe("undeleteAsset", () => {
+    test("returns 401 when not authenticated", async ({ browser }) => {
+      const ctx = await browser.newContext();
+      const req = ctx.request;
+      const res = await req.get(
+        `${baseURL()}/assetManager/undeleteAsset/000000000000000000000000`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(res.status()).toBe(401);
+      const body = await res.json();
+      expect(body).toHaveProperty("error");
+      await ctx.close();
+    });
+
+    test("returns 404 for non-existent asset", async ({ page }) => {
+      const res = await page.request.get(
+        `${baseURL()}/assetManager/undeleteAsset/000000000000000000000000`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(res.status()).toBe(404);
+      const body = await res.json();
+      expect(body).toHaveProperty("error");
+    });
+
+    test("undeletes a soft-deleted asset and returns JSON", async ({
+      page,
+    }) => {
+      const collectionId = await createCollection(
+        page,
+        "Undelete Test Collection",
+      );
+      const template = await createTemplate(page, {
+        name: "Undelete Test Template",
+      });
+      const assetId = await createAsset(page, template.id, collectionId);
+
+      // Soft-delete the asset.
+      const deleteRes = await page.request.get(
+        `${baseURL()}/assetManager/deleteAsset/${assetId}/true`,
+      );
+      expect(deleteRes.status()).toBe(204);
+
+      // Confirm it's gone.
+      const gone = await page.request.get(
+        `${baseURL()}/asset/viewAsset/${assetId}/true`,
+      );
+      expect(gone.status()).toBe(404);
+
+      // Undelete the asset.
+      const undeleteRes = await page.request.get(
+        `${baseURL()}/assetManager/undeleteAsset/${assetId}`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(undeleteRes.status()).toBe(200);
+      const body = await undeleteRes.json();
+      expect(body).toHaveProperty("objectId", assetId);
+
+      // Verify the asset is accessible again.
+      const afterUndelete = await page.request.get(
+        `${baseURL()}/asset/viewAsset/${assetId}/true`,
+      );
+      expect(afterUndelete.status()).toBe(200);
+    });
+  });
+
+  test.describe("restore (perform restore) JSON", () => {
+    test("returns 401 when not authenticated", async ({ browser }) => {
+      const ctx = await browser.newContext();
+      const req = ctx.request;
+      const res = await req.get(
+        `${baseURL()}/assetManager/restore/999999`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(res.status()).toBe(401);
+      const body = await res.json();
+      expect(body).toHaveProperty("error");
+      await ctx.close();
+    });
+
+    test("returns 404 when no revision source exists", async ({ page }) => {
+      // Use a non-existent DB primary key — find() returns null.
+      const res = await page.request.get(
+        `${baseURL()}/assetManager/restore/999999`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(res.status()).toBe(404);
+      const body = await res.json();
+      expect(body).toHaveProperty("error");
+    });
+
+    test("restores a soft-deleted asset and returns JSON", async ({ page }) => {
+      const collectionId = await createCollection(
+        page,
+        "Restore Success Collection",
+      );
+      const template = await createTemplate(page, {
+        name: "Restore Success Template",
+      });
+      const assetId = await createAsset(page, template.id, collectionId);
+
+      // Re-submit to create a revision.
+      await page.request.post(`${baseURL()}/assetManager/submission/true`, {
+        form: {
+          formData: JSON.stringify({
+            objectId: assetId,
+            templateId: template.id,
+            collectionId,
+          }),
+        },
+      });
+
+      // Get the revision list to find a revision indexId.
+      const listRes = await page.request.get(
+        `${baseURL()}/assetManager/restoreAsset/${assetId}`,
+        { headers: { Accept: "application/json" } },
+      );
+      const revisions = await listRes.json();
+      const revisionIndexId = revisions[0].indexId;
+
+      // Soft-delete the asset.
+      const deleteRes = await page.request.get(
+        `${baseURL()}/assetManager/deleteAsset/${assetId}/true`,
+      );
+      expect(deleteRes.status()).toBe(204);
+
+      // Restore via the revision.
+      const restoreRes = await page.request.get(
+        `${baseURL()}/assetManager/restore/${revisionIndexId}`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(restoreRes.status()).toBe(200);
+      const body = await restoreRes.json();
+      expect(body).toHaveProperty("objectId");
+
+      // Verify the asset is accessible again.
+      const afterRestore = await page.request.get(
+        `${baseURL()}/asset/viewAsset/${body.objectId}/true`,
+      );
+      expect(afterRestore.status()).toBe(200);
     });
   });
 });

--- a/tests/api/assets.spec.ts
+++ b/tests/api/assets.spec.ts
@@ -216,10 +216,18 @@ test.describe("assets", () => {
   });
 
   test.describe("undeleteAsset", () => {
+    test("returns 405 for GET requests", async ({ page }) => {
+      const res = await page.request.get(
+        `${baseURL()}/assetManager/undeleteAsset/000000000000000000000000`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(res.status()).toBe(405);
+    });
+
     test("returns 401 when not authenticated", async ({ browser }) => {
       const ctx = await browser.newContext();
       const req = ctx.request;
-      const res = await req.get(
+      const res = await req.post(
         `${baseURL()}/assetManager/undeleteAsset/000000000000000000000000`,
         { headers: { Accept: "application/json" } },
       );
@@ -230,7 +238,7 @@ test.describe("assets", () => {
     });
 
     test("returns 404 for non-existent asset", async ({ page }) => {
-      const res = await page.request.get(
+      const res = await page.request.post(
         `${baseURL()}/assetManager/undeleteAsset/000000000000000000000000`,
         { headers: { Accept: "application/json" } },
       );
@@ -264,7 +272,7 @@ test.describe("assets", () => {
       expect(gone.status()).toBe(404);
 
       // Undelete the asset.
-      const undeleteRes = await page.request.get(
+      const undeleteRes = await page.request.post(
         `${baseURL()}/assetManager/undeleteAsset/${assetId}`,
         { headers: { Accept: "application/json" } },
       );

--- a/tests/api/assets.spec.ts
+++ b/tests/api/assets.spec.ts
@@ -59,4 +59,60 @@ test.describe("assets", () => {
     );
     expect(viewRes.status()).toBe(404);
   });
+  test.describe("deletedAssets", () => {
+    test("returns 401 when not authenticated", async ({ browser }) => {
+      const ctx = await browser.newContext();
+      const req = ctx.request;
+      const res = await req.get(`${baseURL()}/assetManager/deletedAssets`, {
+        headers: { Accept: "application/json" },
+      });
+      expect(res.status()).toBe(401);
+      const body = await res.json();
+      expect(body).toHaveProperty("error");
+      await ctx.close();
+    });
+
+    test("returns empty array when no assets are deleted", async ({ page }) => {
+      const res = await page.request.get(
+        `${baseURL()}/assetManager/deletedAssets`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+      expect(Array.isArray(body)).toBe(true);
+      expect(body).toHaveLength(0);
+    });
+
+    test("returns deleted assets as JSON", async ({ page }) => {
+      const collectionId = await createCollection(
+        page,
+        "Deleted Assets Collection",
+      );
+      const template = await createTemplate(page, {
+        name: "Deleted Assets Template",
+      });
+      const assetId = await createAsset(page, template.id, collectionId);
+
+      // Soft-delete the asset.
+      const deleteRes = await page.request.get(
+        `${baseURL()}/assetManager/deleteAsset/${assetId}/true`,
+      );
+      expect(deleteRes.status()).toBe(204);
+
+      const res = await page.request.get(
+        `${baseURL()}/assetManager/deletedAssets`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+      expect(Array.isArray(body)).toBe(true);
+      expect(body.length).toBeGreaterThan(0);
+      expect(body[0]).toHaveProperty("objectId");
+      expect(body[0]).toHaveProperty("title");
+      expect(body[0]).toHaveProperty("templateId");
+      expect(body[0]).toHaveProperty("deletedAt");
+      expect(body[0]).toHaveProperty("deletedBy");
+      expect(body[0]).toHaveProperty("modifiedDate");
+    });
+  });
 });

--- a/tests/api/assets.spec.ts
+++ b/tests/api/assets.spec.ts
@@ -6,6 +6,7 @@ import {
   createTemplate,
   createCollection,
   createAsset,
+  createUser,
 } from "../helpers";
 
 test.describe("assets", () => {
@@ -128,6 +129,56 @@ test.describe("assets", () => {
       const body = await res.json();
       expect(Array.isArray(body)).toBe(true);
       expect(body).toHaveLength(0);
+    });
+
+    test("only returns assets deleted by the current user", async ({
+      page,
+      browser,
+    }) => {
+      const collectionId = await createCollection(
+        page,
+        "Scoping Test Collection",
+      );
+      const template = await createTemplate(page, {
+        name: "Scoping Test Template",
+      });
+      const assetId = await createAsset(page, template.id, collectionId);
+
+      // Admin deletes the asset.
+      const deleteRes = await page.request.get(
+        `${baseURL()}/assetManager/deleteAsset/${assetId}/true`,
+      );
+      expect(deleteRes.status()).toBe(204);
+
+      // Sanity: admin sees the deleted asset.
+      const adminRes = await page.request.get(
+        `${baseURL()}/assetManager/deletedAssets`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(adminRes.status()).toBe(200);
+      const adminBody = await adminRes.json();
+      expect(adminBody.length).toBeGreaterThan(0);
+
+      // Create a second superadmin user.
+      await createUser(page, "testuser2", "testpass2", {
+        isSuperAdmin: true,
+      });
+
+      // Log in as the second user in a fresh context.
+      const ctx = await browser.newContext();
+      const user2Page = await ctx.newPage();
+      await loginUser(user2Page, "testuser2", "testpass2");
+
+      // Second user should see no deleted assets (they didn't delete any).
+      const user2Res = await user2Page.request.get(
+        `${baseURL()}/assetManager/deletedAssets`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(user2Res.status()).toBe(200);
+      const user2Body = await user2Res.json();
+      expect(user2Body).toHaveLength(0);
+
+      await ctx.close();
     });
 
     test("returns deleted assets as JSON", async ({ page }) => {

--- a/tests/api/assets.spec.ts
+++ b/tests/api/assets.spec.ts
@@ -31,7 +31,7 @@ test.describe("assets", () => {
   // its URL caused a 500 (for assets with uploads) or returned stale data
   // (bare assets). The fix adds a deleted check in Asset::getAsset() and
   // Asset::viewAsset() after loadAssetById() succeeds.
-  test("deleted asset returns 404, not 200", async ({ page }) => {
+  test("deleted asset returns 410 with metadata, not 200", async ({ page }) => {
     const collectionId = await createCollection(page, "Test Collection #467");
     const template = await createTemplate(page, { name: "Test Template #467" });
     const assetId = await createAsset(page, template.id, collectionId);
@@ -48,17 +48,62 @@ test.describe("assets", () => {
     );
     expect(deleteRes.status()).toBe(204);
 
-    // getAsset must return 404 for a soft-deleted asset.
+    // getAsset must return 410 Gone for a soft-deleted asset.
     const getRes = await page.request.get(
       `${baseURL()}/asset/getAsset/${assetId}`,
+      { headers: { Accept: "application/json" } },
     );
-    expect(getRes.status()).toBe(404);
+    expect(getRes.status()).toBe(410);
+    const getBody = await getRes.json();
+    expect(getBody).toHaveProperty("error", "deleted");
+    expect(getBody).toHaveProperty("objectId", assetId);
+    expect(getBody).toHaveProperty("deletedAt");
+    expect(getBody).toHaveProperty("deletedBy");
 
-    // viewAsset must also return 404.
+    // viewAsset must also return 410 Gone.
     const viewRes = await page.request.get(
       `${baseURL()}/asset/viewAsset/${assetId}/true`,
     );
+    expect(viewRes.status()).toBe(410);
+    const viewBody = await viewRes.json();
+    expect(viewBody).toHaveProperty("error", "deleted");
+    expect(viewBody).toHaveProperty("objectId", assetId);
+  });
+
+  test("deleted asset returns 404 (not 410) for users without manage permission", async ({
+    page,
+    browser,
+  }) => {
+    const collectionId = await createCollection(page, "Permission Gate Collection");
+    const template = await createTemplate(page, { name: "Permission Gate Template" });
+    const assetId = await createAsset(page, template.id, collectionId);
+
+    // Admin deletes the asset.
+    const deleteRes = await page.request.get(
+      `${baseURL()}/assetManager/deleteAsset/${assetId}/true`,
+    );
+    expect(deleteRes.status()).toBe(204);
+
+    // Create a non-admin user (no asset management permission).
+    await createUser(page, "viewer", "viewerpass");
+
+    const ctx = await browser.newContext();
+    const viewerPage = await ctx.newPage();
+    await loginUser(viewerPage, "viewer", "viewerpass");
+
+    // Non-admin must get 404, not 410 — no leak that the asset was deleted.
+    const getRes = await viewerPage.request.get(
+      `${baseURL()}/asset/getAsset/${assetId}`,
+      { headers: { Accept: "application/json" } },
+    );
+    expect(getRes.status()).toBe(404);
+
+    const viewRes = await viewerPage.request.get(
+      `${baseURL()}/asset/viewAsset/${assetId}/true`,
+    );
     expect(viewRes.status()).toBe(404);
+
+    await ctx.close();
   });
 
   test.describe("restoreAsset (list revisions) JSON", () => {
@@ -265,11 +310,11 @@ test.describe("assets", () => {
       );
       expect(deleteRes.status()).toBe(204);
 
-      // Confirm it's gone.
+      // Confirm it's gone (410 = deleted).
       const gone = await page.request.get(
         `${baseURL()}/asset/viewAsset/${assetId}/true`,
       );
-      expect(gone.status()).toBe(404);
+      expect(gone.status()).toBe(410);
 
       // Undelete the asset.
       const undeleteRes = await page.request.post(

--- a/tests/api/assets.spec.ts
+++ b/tests/api/assets.spec.ts
@@ -277,7 +277,13 @@ test.describe("assets", () => {
         { headers: { Accept: "application/json" } },
       );
       expect(undeleteRes.status()).toBe(200);
-      const body = await undeleteRes.json();
+
+      // Response must be clean JSON with no PHP errors mixed in.
+      const rawBody = await undeleteRes.text();
+      expect(rawBody).not.toContain("A PHP Error was encountered");
+      expect(rawBody).not.toContain("<div");
+
+      const body = JSON.parse(rawBody);
       expect(body).toHaveProperty("objectId", assetId);
 
       // Verify the asset is accessible again.

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -128,7 +128,7 @@ export async function createCollection(
   return body.id;
 }
 
-// POST /{instance}/assetmanager/submission/true
+// POST /{instance}/assetManager/submission/true
 // formData is a JSON string containing at minimum templateId and collectionId.
 // Returns the new asset's objectId (a 24-char hex MongoDB-style ID).
 export async function createAsset(
@@ -139,7 +139,7 @@ export async function createAsset(
   const formData = JSON.stringify({ templateId, collectionId });
 
   const response = await page.request.post(
-    `${baseURL()}/assetmanager/submission/true`,
+    `${baseURL()}/assetManager/submission/true`,
     { form: { formData } },
   );
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -131,6 +131,34 @@ export async function createCollection(
 // POST /{instance}/assetManager/submission/true
 // formData is a JSON string containing at minimum templateId and collectionId.
 // Returns the new asset's objectId (a 24-char hex MongoDB-style ID).
+// POST /{instance}/permissions/saveUser
+// Creates a local user via the admin permissions controller.
+// The caller must be logged in as an admin.
+export async function createUser(
+  page: Page,
+  username: string,
+  password: string,
+  options: { isSuperAdmin?: boolean; displayName?: string; email?: string } = {},
+): Promise<void> {
+  const response = await page.request.post(
+    `${baseURL()}/permissions/saveUser`,
+    {
+      form: {
+        username,
+        password,
+        label: options.displayName ?? username,
+        email: options.email ?? `${username}@test.local`,
+        isSuperAdmin: options.isSuperAdmin ? "1" : "0",
+      },
+    },
+  );
+
+  if (!response.ok()) {
+    const text = await response.text().catch(() => "unknown");
+    throw new Error(`createUser failed (${response.status()}): ${text}`);
+  }
+}
+
 export async function createAsset(
   page: Page,
   templateId: number,


### PR DESCRIPTION
- add `deletedAssets` endpoint lists soft-deleted assets as JSON, scoped to the current user (by `deletedBy`)
- add `undeleteAsset` endpoint reverses a soft-delete without going through the revision-based restore flow
- `restoreAsset` and `restore` now return JSON when `Accept: application/json` is set
- add check for non-existent entity IDs in `internalRestore()`
- URL casing fix in Playwright tests (`assetmanager` → `assetManager`)

I think this is right, but I'd love a double-check:
- I've scoped `deletedAssets()` to only return assets deleted by the current user. Is that correct?
- I've used the same permissions for `undeleteAsset()`  as `restoreAsset()`.

This complements a forthcoming PR in elevator-ui.