### PR TITLE
add support for split css in manifest.json

### DIFF
--- a/application/views/vueTemplate.php
+++ b/application/views/vueTemplate.php
@@ -92,9 +92,9 @@ function makeJavaScriptConfig($instance, $config, $template) {
     window.Elevator.config.instance.base.url = `${window.location.origin}${window.Elevator.config.instance.base.path}`;
   </script>
   <?=$this->user_model->getAuthHelper()->templateView();?>
-	<?php foreach ($entryCssFiles as $cssFile): ?>
-		<link rel="stylesheet" href="/assets/elevator-ui/dist/<?= $cssFile ?>">
-	<?php endforeach; ?>
+  <?php foreach ($entryCssFiles as $cssFile): ?>
+    <link rel="stylesheet" href="/assets/elevator-ui/dist/<?= $cssFile ?>">
+  <?php endforeach; ?>
     <script type="module" crossorigin src="/assets/elevator-ui/dist/<?= $indexFile ?>"></script>
 </head>
 

--- a/application/views/vueTemplate.php
+++ b/application/views/vueTemplate.php
@@ -11,7 +11,7 @@ if (json_last_error() !== JSON_ERROR_NONE) {
 }
 
 $indexFile = $manifest['src/main.ts']['file'];
-$cssFile = $manifest['style.css']['file'];
+$entryCssFiles = $manifest['src/main.ts']['css'];
 
 $customCSSFile = "/assets/instanceAssets/{$this->instance->getId()}.css";
 $customCSSHash = $this->instance->getModifiedAt()->getTimestamp();
@@ -92,7 +92,9 @@ function makeJavaScriptConfig($instance, $config, $template) {
     window.Elevator.config.instance.base.url = `${window.location.origin}${window.Elevator.config.instance.base.path}`;
   </script>
   <?=$this->user_model->getAuthHelper()->templateView();?>
-  <link rel="stylesheet" href="/assets/elevator-ui/dist/<?= $cssFile ?>">
+	<?php foreach ($entryCssFiles as $cssFile): ?>
+		<link rel="stylesheet" href="/assets/elevator-ui/dist/<?= $cssFile ?>">
+	<?php endforeach; ?>
     <script type="module" crossorigin src="/assets/elevator-ui/dist/<?= $indexFile ?>"></script>
 </head>
 


### PR DESCRIPTION
This adds support for css file splitting in a forthcoming PR for elevator-ui. Instead of a single file, vite returns an array of entry files. The template is updated to loop over the array add a link for each. (In the typical case, this will just be one entry.)