### PR TITLE
feat(permissions): some backend infra for permissions json API

### DIFF
--- a/application/controllers/Permissions.php
+++ b/application/controllers/Permissions.php
@@ -1,4 +1,8 @@
-<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+<?php
+
+use Entity\Permission;
+
+if ( ! defined('BASEPATH')) exit('No direct script access allowed');
 
 class Permissions extends Instance_Controller {
 
@@ -84,6 +88,20 @@ class Permissions extends Instance_Controller {
 		$this->template->content->view('permissions/edit', $data);
 		$this->template->publish();
 
+	}
+
+	/**
+	 * Returns every `Permission` record sorted by `level` ascending. Effectively
+	 * static reference data, which the frontend can cache aggressively.
+	 */
+	public function permissionLevels() {
+		$this->abortUnlessAuthed();
+
+		$permissionLevels = $this->doctrine->em->getRepository(Permission::class)->findBy([], ["level" => "ASC"]);
+
+		return render_json([
+			'permissionLevels' => $permissionLevels,
+		]);
 	}
 
 	public function update()
@@ -351,13 +369,13 @@ class Permissions extends Instance_Controller {
 		//		Class, User, JobCode.
 
 		// There's probably a better way to do this separation, but this seems to make the most sense currently.
-		
+
 		$authHelper = $this->user_model->getAuthHelper();
 
 		$availablePermissions = $authHelper->authTypes;
 
 		$data["authHelper"] = $authHelper;
-		
+
 		$data['groupUser'] = $this->doctrine->em->getRepository("Entity\InstanceGroup")->findBy(['group_type' => USER_TYPE, 'instance' => $this->instance]);
 
 		foreach($availablePermissions as $key=>$value) {
@@ -739,7 +757,7 @@ class Permissions extends Instance_Controller {
 		}
 
 		$authHelper = $this->user_model->getAuthHelper();
-		
+
 		$user = $authHelper->createUserFromRemote($umndid);
 		if(!$user) {return false;}
 		return $user->getId();

--- a/application/core/Instance_Controller.php
+++ b/application/core/Instance_Controller.php
@@ -181,7 +181,7 @@ class Instance_Controller extends MY_Controller
 
     /**
      * Abort a JSON request with 401/403 unless the session user is an
-     * instance admin. Implies `requireAuthed()`.
+     * instance admin. Implies `abortUnlessAuthed()`.
      */
     protected function abortUnlessAdmin(): void {
         $this->abortUnlessAuthed();

--- a/application/core/Instance_Controller.php
+++ b/application/core/Instance_Controller.php
@@ -168,4 +168,25 @@ class Instance_Controller extends MY_Controller
         $accessLevel = $this->user_model?->getAccessLevel('instance', $this->instance) ?? 0;
         return  $accessLevel >= PERM_ADMIN;
     }
+
+    /**
+     * Abort a JSON request with 401 if the session user isn't authenticated.
+     * Use at the top of controller actions that require authentication.
+     */
+    protected function abortUnlessAuthed(): void {
+        if (!$this->isCurrentUserAuthed()) {
+            abort_json(['error' => 'Unauthorized'], 401);
+        }
+    }
+
+    /**
+     * Abort a JSON request with 401/403 unless the session user is an
+     * instance admin. Implies `requireAuthed()`.
+     */
+    protected function abortUnlessAdmin(): void {
+        $this->abortUnlessAuthed();
+        if (!$this->isCurrentUserAdmin()) {
+            abort_json(['error' => 'Forbidden'], 403);
+        }
+    }
 }

--- a/application/models/Entity/CollectionPermission.php
+++ b/application/models/Entity/CollectionPermission.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
  */
 #[ORM\Table(name: 'collection_permissions')]
 #[ORM\Entity]
-class CollectionPermission
+class CollectionPermission implements \JsonSerializable
 {
     /**
      * @var int
@@ -122,5 +122,15 @@ class CollectionPermission
     public function getPermission()
     {
         return $this->permission;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'id'                => $this->id,
+            'collectionId'      => $this->collection?->getId(),
+            'groupId'           => $this->group?->getId(),
+            'permissionLevelId' => $this->permission?->getId(),
+        ];
     }
 }

--- a/application/models/Entity/DrawerPermission.php
+++ b/application/models/Entity/DrawerPermission.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
  */
 #[ORM\Table(name: 'drawer_permissions')]
 #[ORM\Entity]
-class DrawerPermission
+class DrawerPermission implements \JsonSerializable
 {
     /**
      * @var int
@@ -122,5 +122,15 @@ class DrawerPermission
     public function getPermission()
     {
         return $this->permission;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'id'                => $this->id,
+            'drawerId'          => $this->drawer?->getId(),
+            'drawerGroupId'     => $this->group?->getId(),
+            'permissionLevelId' => $this->permission?->getId(),
+        ];
     }
 }

--- a/application/models/Entity/InstancePermission.php
+++ b/application/models/Entity/InstancePermission.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
  */
 #[ORM\Table(name: 'instance_permissions')]
 #[ORM\Entity]
-class InstancePermission
+class InstancePermission implements \JsonSerializable
 {
     /**
      * @var int
@@ -122,5 +122,14 @@ class InstancePermission
     public function getPermission()
     {
         return $this->permission;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'id'                => $this->id,
+            'groupId'           => $this->group?->getId(),
+            'permissionLevelId' => $this->permission?->getId(),
+        ];
     }
 }

--- a/application/models/Entity/Permission.php
+++ b/application/models/Entity/Permission.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
  */
 #[ORM\Table(name: 'permissions')]
 #[ORM\Entity]
-class Permission
+class Permission implements \JsonSerializable
 {
     /**
      * @var string|null
@@ -228,5 +228,19 @@ class Permission
     public function getInstances()
     {
         return $this->instances;
+    }
+
+    /**
+     * JSON shape consumed by the admin UI. `level` is stored as a nullable
+     * string column on the entity for historical reasons; cast to int on the
+     * way out so the frontend doesn't need to reparse it.
+     */
+    public function jsonSerialize(): array {
+        return [
+            'id'    => $this->id,
+            'level' => (int) ($this->level ?? 0),
+            'name'  => $this->name,
+            'label' => $this->label,
+        ];
     }
 }

--- a/tests/api/permissions.spec.ts
+++ b/tests/api/permissions.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "@playwright/test";
+import { loginUser, baseURL } from "../helpers";
+
+test.describe("permissions", () => {
+  test.describe("GET /permissions/permissionLevels", () => {
+    test("returns 401 when not authenticated", async ({ page }) => {
+      const res = await page.request.get(
+        `${baseURL()}/permissions/permissionLevels`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(res.status()).toBe(401);
+    });
+
+    test.describe("when authenticated", () => {
+      test.beforeEach(async ({ page }) => {
+        await loginUser(
+          page,
+          process.env.ADMIN_USERNAME ?? "admin",
+					process.env.DEFAULT_ADMIN_PASSWORD ?? "admin",
+        );
+      });
+
+      test("returns 200 with permissionLevels array", async ({ page }) => {
+        const res = await page.request.get(
+          `${baseURL()}/permissions/permissionLevels`,
+          { headers: { Accept: "application/json" } },
+        );
+        expect(res.status()).toBe(200);
+
+        const body = await res.json();
+        expect(body).toHaveProperty("permissionLevels");
+        expect(Array.isArray(body.permissionLevels)).toBe(true);
+        expect(body.permissionLevels.length).toBeGreaterThan(0);
+      });
+
+      test("each level has id, level, name, label fields", async ({ page }) => {
+        const res = await page.request.get(
+          `${baseURL()}/permissions/permissionLevels`,
+          { headers: { Accept: "application/json" } },
+        );
+        const { permissionLevels } = await res.json();
+
+        for (const item of permissionLevels) {
+          expect(typeof item.id).toBe("number");
+          expect(typeof item.level).toBe("number");
+          expect(typeof item.name).toBe("string");
+          expect(typeof item.label).toBe("string");
+        }
+      });
+
+      test("levels are sorted ascending by level", async ({ page }) => {
+        const res = await page.request.get(
+          `${baseURL()}/permissions/permissionLevels`,
+          { headers: { Accept: "application/json" } },
+        );
+        const { permissionLevels } = await res.json();
+
+        const levels = permissionLevels.map(
+          (p: { level: number }) => p.level,
+        );
+        expect(levels).toEqual([...levels].sort((a, b) => a - b));
+      });
+    });
+  });
+});

--- a/tests/api/permissions.spec.ts
+++ b/tests/api/permissions.spec.ts
@@ -13,10 +13,16 @@ test.describe("permissions", () => {
 
     test.describe("when authenticated", () => {
       test.beforeEach(async ({ page }) => {
+        const adminPassword = process.env.DEFAULT_ADMIN_PASSWORD;
+        test.skip(
+          !adminPassword,
+          "DEFAULT_ADMIN_PASSWORD must be set for authenticated permissions tests",
+        );
+
         await loginUser(
           page,
           process.env.ADMIN_USERNAME ?? "admin",
-					process.env.DEFAULT_ADMIN_PASSWORD ?? "admin",
+          adminPassword,
         );
       });
 


### PR DESCRIPTION
Lays the foundation for the admin permissions API (#[538](https://github.com/UMN-LATIS/elevator-ui/issues/538)).

- Add `abortUnlessAuthed()` / `abortUnlessAdmin()` guards to `Instance_Controller`
- Implement `JsonSerializable` on `Permission`, `InstancePermission`, `CollectionPermission`, `DrawerPermission`. JSON shapes mirror the expected elevator-ui frontend types.
- Add `GET /permissions/permissionLevels`.
- Add Playwright API tests for the new endpoint (auth gate, shape, field types, sort order)

No migrations. No existing behavior changed.
