### PR TITLE
fix: docker build fails during mongodb step

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.4-fpm
 
 
-RUN apt update && apt install -y unzip git libpq-dev  libzip-dev && apt clean
+RUN apt update && apt install -y unzip git libpq-dev libzstd-dev libzip-dev && apt clean
 RUN pecl install redis && docker-php-ext-enable redis
 RUN docker-php-ext-install pgsql pdo_pgsql pdo zip
 # RUN export CFLAGS="-D_DEFAULT_SOURCE"
@@ -11,7 +11,7 @@ RUN pecl install mongodb && docker-php-ext-enable mongodb
 RUN docker-php-ext-install sockets
 COPY docker/get-docker.sh /root/
 RUN chmod +x /root/get-docker.sh
-RUN /root/get-docker.sh 
+RUN /root/get-docker.sh
 
 # add ldap php module
 RUN apt-get update && apt-get install -y libldap2-dev libldap-common


### PR DESCRIPTION
building docker image fails at the mongodb extension step:

```
20.61 /tmp/pear/temp/mongodb/src/libmongoc/src/libmongoc/src/mongoc/mongoc-compression.c:34:10: fatal error: zstd.h: No such file or directory
20.61    34 | #include <zstd.h>
20.61       |          ^~~~~~~~
20.61 compilation terminated.
20.61 make: *** [Makefile:502: src/libmongoc/src/libmongoc/src/mongoc/mongoc-compression.lo] Error 1
20.63 ERROR: `make' failed
------
...
target reindex-worker: failed to solve: process "/bin/sh -c pecl install mongodb && docker-php-ext-enable mongodb" did not complete successfully: exit code: 1
```

This adds `libzstd-dev` package to include the missing header.