### PR TITLE
update getOriginal to support vue-ui and json requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ ENCRYPTION_KEY=somerandomstuffgoeshere
 # Accepted values: development, local, testing, production.
 # Use 'local' for normal dev work. Production servers must set this to 'production'.
 CI_ENV=local
+ENVIRONMENT=local # needed for runJob.sh
 AUTH_HELPER=AuthHelper
 
 REDIS_HOST=redis

--- a/application/controllers/FileManager.php
+++ b/application/controllers/FileManager.php
@@ -395,98 +395,109 @@ class FileManager extends Instance_Controller {
 
 	}
 
-	/**
-	 * Get a file's original. Behavior depends on $action:
-	 *
-	 *   'download' (default) - redirect (307) when downloadable; otherwise queue
-	 *       a restore and render the "restoring" page. Legacy path.
-	 *   'status'  - return JSON archival status ('downloadable' | 'archived' |
-	 *       'restoring'); never restores or redirects, so it's safe to poll.
-	 *   'restore' - queue a Glacier restore. POST only; returns 202.
-	 *
-	 * Requires PERM_ORIGINALS, or the file handler's getPermission() level when
-	 * the file has no derivatives.
-	 *
-	 * @param string $fileId - File handler object id to load.
-	 * @param 'download'|'status'|'restore' $action
-	 */
-	function getOriginal(?string $fileId, string $action = 'download') {
+  /**
+   * Get a file's original. Behavior depends on $action:
+   *
+   * @param string $fileId - File handler object id to load.
+   * @param 'legacyDownload'|'download'|'status'|'restore' $action
+   *  'legacyDownload' (default) - Download or kick off restore if archived, then show "Give us a moment" page. This is the old behavior and is still used by the legacy UI.
+   * 'download' - Download, only if available. Does NOT kick
+   * off a restore. Returns error if the requested file isn't
+   * available.
+   * 'restore' - POST-only endpoint to kick off a restore.
+   * .'status' - Check storage status of the original. Returns
+   *  {"status": "archived"|"restoring"|"available"}
+   */
+  function getOriginal(?string $fileId, string $action = 'legacyDownload') {
     $isJson = $this->isJsonRequest();
 
-		$fileHandler = $this->filehandler_router->getHandlerForObject($fileId);
-		$fileHandler->loadByObjectId($fileId);
-		if(!($fileHandler)) {
+    $fileHandler = $this->filehandler_router->getHandlerForObject($fileId);
+    $fileHandler->loadByObjectId($fileId);
+    if (!($fileHandler)) {
       return $isJson
         ? abort_json(["error" => "unknownFile"], 404)
         : instance_redirect("errorHandler/error/unknownFile");
-		}
+    }
 
-		if(!$this->asset_model->loadAssetById($fileHandler->parentObjectId)) {
-			$this->logging->logError("getOriginal", "could not load asset from fileHandler" . $fileId);
+    if (!$this->asset_model->loadAssetById($fileHandler->parentObjectId)) {
+      $this->logging->logError("getOriginal", "could not load asset from fileHandler" . $fileId);
       return $isJson
         ? abort_json(["error" => "unknownFile"], 404)
         : instance_redirect("errorHandler/error/unknownFile");
-		}
+    }
 
-		$accessLevel = $this->user_model->getAccessLevel("asset", $this->asset_model);
+    $accessLevel = $this->user_model->getAccessLevel("asset", $this->asset_model);
 
-		/**
-		 * if this file type specifies that it doesn't have derivatives, users need lower
-		 * permission levels to get to the original.
-		 */
-		if($fileHandler->noDerivatives()) {
-			$requiredAccessLevel = $fileHandler->getPermission();
-		}
-		else {
-			$requiredAccessLevel = PERM_ORIGINALS;
-		}
+    /**
+     * if this file type specifies that it doesn't have derivatives, users need lower
+     * permission levels to get to the original.
+     */
+    if ($fileHandler->noDerivatives()) {
+      $requiredAccessLevel = $fileHandler->getPermission();
+    } else {
+      $requiredAccessLevel = PERM_ORIGINALS;
+    }
 
-		if($accessLevel < $requiredAccessLevel) {
+    if ($accessLevel < $requiredAccessLevel) {
       return $isJson
-        ? abort_json([ "error" => "noPermission" ], 403)
-			  : instance_redirect("/errorHandler/error/noPermission");
-		}
+        ? abort_json(["error" => "noPermission"], 403)
+        : instance_redirect("/errorHandler/error/noPermission");
+    }
 
     // status: idempotent, no side effects — safe to poll.
     if ($action == "status") {
       return render_json([
         "status" => $fileHandler->sourceFile->getArchiveStatus()
-  ]);
+      ]);
     }
 
     // restore: an explicit mutation, so POST only — also keeps link prefetchers
     // from kicking off expensive Glacier restores.
-    if($action == "restore") {
-      if($this->input->method() !== 'post') {
+    if ($action == "restore") {
+      if ($this->input->method() !== 'post') {
         return abort_json(["error" => "methodNotAllowed"], 405);
       }
       $this->queueRestore($fileHandler, $fileId);
       return render_json([
         "status" => "restoring",
-        "message" => "file is being restored, you will be notified when it's ready"], 202);
+        "message" => "file is being restored, you will be notified when it's ready"
+      ], 202);
     }
 
-    // download (default): redirect when downloadable, otherwise restore + show
-    // the restoring page. Legacy frontend (no action) lands here.
-		if($fileHandler->sourceFile->isArchived(true)) {
-			$this->queueRestore($fileHandler, $fileId);
+    // if we're trying to download an archived file
+    $isArchived = $fileHandler->sourceFile->isArchived(true);
+    if ($isArchived && $action == "download") {
+      // the new ui gets an error when requesting
+      // a download when the archived file is not ready.
+      // this prevents downloading the response page
+      // as if it were the original. See #546.
+        return abort_json([
+          "error" => "fileArchived",
+          "message" => "Cannot download an archived file. Please wait for restore to complete before downloading."
+        ], 409);
+    }
 
-			$this->template->content->view('restoringFile');
-			$this->template->publish();
-			return;
-		}
+    if ($isArchived && $action == "legacyDownload") {
+        // legacy behavior: kick off restore + show "Give us a moment" page
+        $this->queueRestore($fileHandler, $fileId);
+        $this->template->content->view('restoringFile');
+        $this->template->publish();
+        return;
+    }
 
-		try {
-			$targetURL = $fileHandler->sourceFile->getProtectedURLForFile();
-		}
-		catch (Exception $e) {
+    try {
+      /** @var FilecontainerS3 */
+      $sourceFile = $fileHandler->sourceFile;
+      $targetURL = $sourceFile->getProtectedURLForFile();
+    } catch (Exception $e) {
       return $isJson
         ? abort_json(["error" => "originalNotAvailable"], 404)
         : instance_redirect("/errorHandler/error/originalNotAvailable");
-		}
+    }
 
+    // happy path: redirect to the original file on S3.
     return redirect(matchScheme($targetURL), 307);
-	}
+  }
 
   /**
    * Queue a Glacier restore for a file: enqueue a beanstalkd job to notify the

--- a/application/controllers/FileManager.php
+++ b/application/controllers/FileManager.php
@@ -5,6 +5,18 @@
  * Handles serving any digital asset, via redirects to S3
  * This class could use some cleanup - it has some convenience methods that probably don't need to be around anymore.
  * It has a lot of anti-DRY code too
+ *
+ * The @property tags cover CodeIgniter's magic loader properties.
+ *
+ * @property Filehandler_router $filehandler_router
+ * @property Asset_model $asset_model
+ * @property User_model $user_model
+ * @property Errorhandler_helper $errorhandler_helper
+ * @property Logging $logging
+ * @property Template $template
+ * @property CI_Loader $load
+ * @property CI_Config $config
+ * @property CI_Input $input
  */
 class FileManager extends Instance_Controller {
 
@@ -383,20 +395,37 @@ class FileManager extends Instance_Controller {
 
 	}
 
-
-	function getOriginal($fileId) {
+	/**
+	 * Get a file's original. Behavior depends on $action:
+	 *
+	 *   'download' (default) - redirect (307) when downloadable; otherwise queue
+	 *       a restore and render the "restoring" page. Legacy path.
+	 *   'status'  - return JSON archival status ('downloadable' | 'archived' |
+	 *       'restoring'); never restores or redirects, so it's safe to poll.
+	 *   'restore' - queue a Glacier restore. POST only; returns 202.
+	 *
+	 * Requires PERM_ORIGINALS, or the file handler's getPermission() level when
+	 * the file has no derivatives.
+	 *
+	 * @param string $fileId - File handler object id to load.
+	 * @param 'download'|'status'|'restore' $action
+	 */
+	function getOriginal(?string $fileId, string $action = 'download') {
+    $isJson = $this->isJsonRequest();
 
 		$fileHandler = $this->filehandler_router->getHandlerForObject($fileId);
 		$fileHandler->loadByObjectId($fileId);
 		if(!($fileHandler)) {
-			instance_redirect("errorHandler/error/unknownFile");
-			return;
+      return $isJson
+        ? abort_json(["error" => "unknownFile"], 404)
+        : instance_redirect("errorHandler/error/unknownFile");
 		}
 
 		if(!$this->asset_model->loadAssetById($fileHandler->parentObjectId)) {
 			$this->logging->logError("getOriginal", "could not load asset from fileHandler" . $fileId);
-			instance_redirect("errorHandler/error/unknownFile");
-			return;
+      return $isJson
+        ? abort_json(["error" => "unknownFile"], 404)
+        : instance_redirect("errorHandler/error/unknownFile");
 		}
 
 		$accessLevel = $this->user_model->getAccessLevel("asset", $this->asset_model);
@@ -413,24 +442,37 @@ class FileManager extends Instance_Controller {
 		}
 
 		if($accessLevel < $requiredAccessLevel) {
-			instance_redirect("/errorHandler/error/noPermission");
+      return $isJson
+        ? abort_json([ "error" => "noPermission" ], 403)
+			  : instance_redirect("/errorHandler/error/noPermission");
 		}
 
+    // status: idempotent, no side effects — safe to poll.
+    if ($action == "status") {
+      return render_json([
+        "status" => $fileHandler->sourceFile->getArchiveStatus()
+  ]);
+    }
+
+    // restore: an explicit mutation, so POST only — also keeps link prefetchers
+    // from kicking off expensive Glacier restores.
+    if($action == "restore") {
+      if($this->input->method() !== 'post') {
+        return abort_json(["error" => "methodNotAllowed"], 405);
+      }
+      $this->queueRestore($fileHandler, $fileId);
+      return render_json([
+        "status" => "restoring",
+        "message" => "file is being restored, you will be notified when it's ready"], 202);
+    }
+
+    // download (default): redirect when downloadable, otherwise restore + show
+    // the restoring page. Legacy frontend (no action) lands here.
 		if($fileHandler->sourceFile->isArchived(true)) {
-
-			$pheanstalk =  Pheanstalk\Pheanstalk::create($this->config->item("beanstalkd"));
-			$tube = new Pheanstalk\Values\TubeName('restoreTube');
-			// run a 15 minute TTR because zipping all these could take a while
-			$pheanstalk->useTube($tube);
-
-
-			$pathToFile = instance_url("/fileManager/getOriginal/".$fileId);
-			$newTask = json_encode(["objectId"=>$fileHandler->getObjectId(), "userContact"=>$this->user_model->getEmail(), "instance"=>$this->instance->getId(), "pathToFile"=>$pathToFile, "nextTask"=>"notify"]);
-			$jobId= $pheanstalk->put($newTask, Pheanstalk\Pheanstalk::DEFAULT_PRIORITY, 1);
+			$this->queueRestore($fileHandler, $fileId);
 
 			$this->template->content->view('restoringFile');
 			$this->template->publish();
-			$fileHandler->sourceFile->restoreFromArchive();
 			return;
 		}
 
@@ -438,11 +480,36 @@ class FileManager extends Instance_Controller {
 			$targetURL = $fileHandler->sourceFile->getProtectedURLForFile();
 		}
 		catch (Exception $e) {
-			instance_redirect("/errorHandler/error/originalNotAvailable");
+      return $isJson
+        ? abort_json(["error" => "originalNotAvailable"], 404)
+        : instance_redirect("/errorHandler/error/originalNotAvailable");
 		}
 
-		redirect(matchScheme($targetURL), 307);
+    return redirect(matchScheme($targetURL), 307);
+	}
 
+  /**
+   * Queue a Glacier restore for a file: enqueue a beanstalkd job to notify the
+   * user once the thaw finishes, then kick off the S3 restore itself.
+   * restoreFromArchive() is a no-op on S3 when a restore is already in flight.
+   */
+  private function queueRestore(FileHandlerBase $fileHandler, string $fileId) {
+    $pheanstalk = Pheanstalk\Pheanstalk::create($this->config->item("beanstalkd"));
+    $tube = new Pheanstalk\Values\TubeName('restoreTube');
+    // run a 15 minute TTR because zipping all these could take a while
+    $pheanstalk->useTube($tube);
+
+    $pathToFile = instance_url("/fileManager/getOriginal/" . $fileId);
+    $newTask = json_encode([
+      "objectId" => $fileHandler->getObjectId(),
+      "userContact" => $this->user_model->getEmail(),
+      "instance" => $this->instance->getId(),
+      "pathToFile" => $pathToFile,
+      "nextTask" => "notify"
+    ]);
+    $pheanstalk->put($newTask, Pheanstalk\Pheanstalk::DEFAULT_PRIORITY, 1);
+
+    $fileHandler->sourceFile->restoreFromArchive();
 	}
 
 	function getMetadataForObject($fileId) {

--- a/application/models/Filecontainers3.php
+++ b/application/models/Filecontainers3.php
@@ -9,6 +9,19 @@
  **
 */
 require_once("Filecontainer.php");
+
+/**
+ * S3-backed file container — stores and retrieves a file (and its derivatives)
+ * on S3, including Glacier archive/restore handling.
+ *
+ * The @property tags cover CodeIgniter's magic loader properties so that
+ * command-click and autocomplete resolve on them.
+ *
+ * @property CI_Loader $load
+ * @property CI_Config $config
+ * @property Logging $logging
+ * @property \Entity\Instance $instance
+ */
 class FileContainerS3 extends FileContainer {
 
 	private $client;
@@ -92,6 +105,29 @@ class FileContainerS3 extends FileContainer {
 		$this->parent->s3model->restoreObject($this->storageKey);
 		return true;
 	}
+
+	/**
+	 * Archival status as a single discriminant, with no side effects:
+	 *   'downloadable' - hot, or a completed restore (temp copy available now).
+	 *   'restoring' - a Glacier restore is in progress.
+	 *   'archived' - cold in Glacier, no restore in flight.
+	 *
+	 * Unlike isArchived(true), this never kicks off a restore, so it's safe to
+	 * poll. getStorageClass() reports both cold and in-progress as "GLACIER", so
+	 * we read the Restore header to separate the two.
+   *
+   * @return "downloadable"|"restoring"|"archived"
+	 */
+  public function getArchiveStatus() {
+    if (!$this->isArchived()) {
+      return "downloadable";
+    }
+    $objectInfo = $this->parent->s3model->objectInfo($this->storageKey);
+    if (isset($objectInfo['Restore']) && $objectInfo['Restore'] == 'ongoing-request="true"') {
+      return "restoring";
+    }
+    return "archived";
+  }
 
 	public function removeLocalFile() {
 		if(unlink($this->getPathToLocalFile())) {

--- a/application/models/S3_model.php
+++ b/application/models/S3_model.php
@@ -7,542 +7,542 @@ use Aws\Exception\MultipartUploadException;
 
 class S3_model extends CI_Model {
 
-	public \Aws\S3\S3Client $s3Client;
-	private $secret;
-	private $key;
-	public $bucket;
-	public $sessionToken = null;
-	public $transferCount = 0;
+  public \Aws\S3\S3Client $s3Client;
+  private $secret;
+  private $key;
+  public $bucket;
+  public $sessionToken = null;
+  public $transferCount = 0;
 
-	public function __construct($collection = null) {
-		parent::__construct();
-		if ($collection) {
-			$this->loadFromCollection($collection);
-		}
-	}
+  public function __construct($collection = null) {
+    parent::__construct();
+    if ($collection) {
+      $this->loadFromCollection($collection);
+    }
+  }
 
-	/**
-	 * For generating s3 urls (s3://)
-	 * @return [type] [description]
-	 */
-	public function getSecretKeyPair() {
-		return urlencode(urlencode($this->key)) . ":" . urlencode(urlencode($this->secret));
-	}
+  /**
+   * For generating s3 urls (s3://)
+   * @return [type] [description]
+   */
+  public function getSecretKeyPair() {
+    return urlencode(urlencode($this->key)) . ":" . urlencode(urlencode($this->secret));
+  }
 
-	public function loadFromCollection($collection) {
+  public function loadFromCollection($collection) {
 
-		if (is_numeric($collection)) {
-			$collection = $this->collection_model->getCollection($collection);
-		}
+    if (is_numeric($collection)) {
+      $collection = $this->collection_model->getCollection($collection);
+    }
 
-		$this->secret = $collection->getS3Secret();
-		$this->key = $collection->getS3Key();
-		$this->bucket = $collection->getBucket();
-		$this->s3Client = $this->collection_model->getS3ClientForCollection($collection->getId());
-	}
+    $this->secret = $collection->getS3Secret();
+    $this->key = $collection->getS3Key();
+    $this->bucket = $collection->getBucket();
+    $this->s3Client = $this->collection_model->getS3ClientForCollection($collection->getId());
+  }
 
-	public function loadFromInstance($instance) {
+  public function loadFromInstance($instance) {
 
-		$this->secret = $instance->getAmazonS3Secret();
-		$this->key = $instance->getAmazonS3Key();
-		$this->bucket = $instance->getDefaultBucket();
-		$this->s3Client = $this->s3_model->s3Client =  Aws\S3\S3Client::factory(array(
-			'credentials' => [
-				'key'    => $this->key,
-				'secret' =>  $this->secret
-			],
-			"scheme" => "https",
-			"version" => "2006-03-01",
-			"use_path_style_endpoint" => true,
-			"region" => $instance->getBucketRegion()
-		));
-	}
+    $this->secret = $instance->getAmazonS3Secret();
+    $this->key = $instance->getAmazonS3Key();
+    $this->bucket = $instance->getDefaultBucket();
+    $this->s3Client = $this->s3_model->s3Client =  Aws\S3\S3Client::factory(array(
+      'credentials' => [
+        'key'    => $this->key,
+        'secret' =>  $this->secret
+      ],
+      "scheme" => "https",
+      "version" => "2006-03-01",
+      "use_path_style_endpoint" => true,
+      "region" => $instance->getBucketRegion()
+    ));
+  }
 
-	public function fixACL($sourceFile) {
-		if (strlen($this->bucket) < 5) {
-			echo "Error: bucket unknown\n";
-			throw new Exception('Bucket Error');
-		}
+  public function fixACL($sourceFile) {
+    if (strlen($this->bucket) < 5) {
+      echo "Error: bucket unknown\n";
+      throw new Exception('Bucket Error');
+    }
 
-		$command = [
-			'ACL' => 'private',
-			'Bucket' => $this->bucket,
-			'Key' => "original/" . strrev($sourceFile) . "-source"
-		];
-		try {
-			$this->s3Client->putObjectAcl($command);
-		} catch (Aws\S3\Exception\S3Exception $e) {
-			var_dump($command);
-			echo $e->getAwsErrorType() . "\n";
-			echo $e->getAwsErrorCode() . "\n";
-			throw new Exception('Error setting ACL');
-		}
-	}
+    $command = [
+      'ACL' => 'private',
+      'Bucket' => $this->bucket,
+      'Key' => "original/" . strrev($sourceFile) . "-source"
+    ];
+    try {
+      $this->s3Client->putObjectAcl($command);
+    } catch (Aws\S3\Exception\S3Exception $e) {
+      var_dump($command);
+      echo $e->getAwsErrorType() . "\n";
+      echo $e->getAwsErrorCode() . "\n";
+      throw new Exception('Error setting ACL');
+    }
+  }
 
-	public function putObject($sourceFile, $destKey, $storageClass = AWS_REDUCED, $targetMimeType = null, $contentEncoding = null) {
-		if (!file_exists($sourceFile)) {
-			$this->logging->logError("putObject", "file no longer exists", $sourceFile);
-			return false;
-		}
+  public function putObject($sourceFile, $destKey, $storageClass = AWS_REDUCED, $targetMimeType = null, $contentEncoding = null) {
+    if (!file_exists($sourceFile)) {
+      $this->logging->logError("putObject", "file no longer exists", $sourceFile);
+      return false;
+    }
 
-		if (!$targetMimeType) {
-			$targetMimeType = mime_content_type($sourceFile);
-		}
+    if (!$targetMimeType) {
+      $targetMimeType = mime_content_type($sourceFile);
+    }
 
-		if (filesize($sourceFile) < 100 * 1024 * 1024) {
-			try {
-				$fp = fopen($sourceFile, "rb");
-				$this->s3Client->putObject(array(
-					'Bucket' => $this->bucket,
-					'Key'    => $destKey,
-					'Body'   => $fp,
-					'StorageClass'   => $storageClass,
-					"ContentType" => $targetMimeType,
-					"ContentEncoding" => $contentEncoding
-				));
-				fclose($fp);
-			} catch (Exception $e) {
-				$this->logging->logError("putObject", $e, $sourceFile);
-				return false;
-			} catch (\Aws\S3\Exception\S3Exception $e) {
-				$this->logging->logError("putObject", $e, $sourceFile);
-				return false;
-			}
-		} else {
+    if (filesize($sourceFile) < 100 * 1024 * 1024) {
+      try {
+        $fp = fopen($sourceFile, "rb");
+        $this->s3Client->putObject(array(
+          'Bucket' => $this->bucket,
+          'Key'    => $destKey,
+          'Body'   => $fp,
+          'StorageClass'   => $storageClass,
+          "ContentType" => $targetMimeType,
+          "ContentEncoding" => $contentEncoding
+        ));
+        fclose($fp);
+      } catch (Exception $e) {
+        $this->logging->logError("putObject", $e, $sourceFile);
+        return false;
+      } catch (\Aws\S3\Exception\S3Exception $e) {
+        $this->logging->logError("putObject", $e, $sourceFile);
+        return false;
+      }
+    } else {
 
-			$this->transferCount = 0;
-			$beforeFunction = function (Aws\Command $command) {
-				$this->transferCount++;
-				if ($this->transferCount % 10 == 0) {
-					if (@$this->pheanstalk !== null && @$this->job !== null) {
-						$this->pheanstalk->touch($this->job);
-					}
-				}
-			};
+      $this->transferCount = 0;
+      $beforeFunction = function (Aws\Command $command) {
+        $this->transferCount++;
+        if ($this->transferCount % 10 == 0) {
+          if (@$this->pheanstalk !== null && @$this->job !== null) {
+            $this->pheanstalk->touch($this->job);
+          }
+        }
+      };
 
-			$uploader = new \Aws\S3\MultipartUploader($this->s3Client, $sourceFile, [
-				'bucket' => $this->bucket,
-				'key'    => $destKey,
-				'before_initiate' => function (\Aws\Command $command) use ($targetMimeType, $storageClass)  //  HERE IS THE RELEVANT CODE
-				{
-					$command['ContentType'] = $targetMimeType;
-					$command['StorageClass'] = $storageClass;
-				},
-				"before_upload" => $beforeFunction
-			]);
+      $uploader = new \Aws\S3\MultipartUploader($this->s3Client, $sourceFile, [
+        'bucket' => $this->bucket,
+        'key'    => $destKey,
+        'before_initiate' => function (\Aws\Command $command) use ($targetMimeType, $storageClass)  //  HERE IS THE RELEVANT CODE
+        {
+          $command['ContentType'] = $targetMimeType;
+          $command['StorageClass'] = $storageClass;
+        },
+        "before_upload" => $beforeFunction
+      ]);
 
-			do {
-				try {
-					$result = $uploader->upload();
-				} catch (MultipartUploadException $e) {
-					$uploader = new \Aws\S3\MultipartUploader($this->s3Client, $sourceFile, [
-						'state' => $e->getState(),
-					]);
-				}
-			} while (!isset($result));
+      do {
+        try {
+          $result = $uploader->upload();
+        } catch (MultipartUploadException $e) {
+          $uploader = new \Aws\S3\MultipartUploader($this->s3Client, $sourceFile, [
+            'state' => $e->getState(),
+          ]);
+        }
+      } while (!isset($result));
 
-			return $result ? true : false;
-		}
-
-
-		return true;
-	}
+      return $result ? true : false;
+    }
 
 
-	public function putDirectory($sourceDirectory, $destKey, $storageClass = AWS_REDUCED, $job = null) {
-		try {
-			$options["concurrency"] = 50;
-			$this->storageClass = $storageClass;
-			if (!$this->storageClass) {
-				$this->storageClass = AWS_REDUCED;
-			}
-
-			$this->transferCount = 0;
-			if ($job) {
-				$this->job = $job;
-			}
-			$beforeFunction = function (Aws\Command $command) {
-				if (in_array($command->getName(), ['PutObject', 'CreateMultipartUpload'])) {
-					// Set custom cache-control metadata
-					// $this->logging->logError("storage class", $this->storageClass);
-					$command['StorageClass'] = $this->storageClass;
-				}
-
-				$this->transferCount++;
-				if ($this->transferCount % 100 == 0) {
-					if ($this->pheanstalk !== null && $this->job !== null) {
-						$this->pheanstalk->touch($this->job);
-					}
-
-					echo ".";
-				}
-			};
-
-			if ($beforeFunction) {
-				$options["before"] = $beforeFunction;
-			} else {
-				$options["before"] = function (Aws\Command $command) {
-				};
-			}
-			$destinationPath = "s3://" . $this->bucket . "/" . $destKey;
-			$manager = new \Aws\S3\Transfer($this->s3Client, $sourceDirectory, $destinationPath, $options);
-			$manager->transfer();
-		} catch (Aws\Exception\AwsException $e) {
-			echo $sourceDirectory . "\n";
-			echo $destKey . "\n";
-			$this->logging->logError("uploadDirectory", $e);
-			return false;
-		}
-		return true;
-	}
-
-	public function getObject($sourceKey, $destFile) {
-		try {
-			$result = $this->s3Client->getObject(array(
-				'Bucket' => $this->bucket,
-				'Key'    => $sourceKey,
-				'SaveAs' => $destFile
-			));
-		} catch (Exception $e) {
-			$this->logging->logError("getObject", $e, $sourceKey);
-			return false;
-		}
-
-		return true;
-	}
-
-	public function objectInfo($targetKey) {
-		try {
-			$result = $this->s3Client->headObject([
-				'Bucket' => $this->bucket,
-				'Key'    => $targetKey
-			]);
-			return $result;
-		} catch (Exception $e) {
-			$this->logging->logError("objectInfo", $e->getMessage(), $targetKey);
-			return false;
-		}
-	}
-
-	public function getFilesAtKeyPath($targetKey) {
-		try {
-
-			$truncated = true;
-			$nextMarker = null;
-			$mergedContents  = array();
-			while ($truncated == true) {
-				$result = $this->s3Client->listObjects([
-					'Bucket' => $this->bucket,
-					'Prefix'    => $targetKey,
-					'Marker' => $nextMarker
-				]);
-
-				$mergedContents = array_merge($mergedContents, $result['Contents']);
-				if ($result['IsTruncated'] == true) {
-					$lastElement = $result['Contents'][count($result['Contents']) - 1];
-					$nextMarker = $lastElement['Key'];
-				} else {
-					$truncated = false;
-				}
-			}
-
-			$fileList = array();
-			foreach ($mergedContents as $entry) {
-				$fileList[] = $entry['Key'];
-			}
-			return $fileList;
-		} catch (Exception $e) {
-			$this->logging->logError("getFilesAtKeyPath", $e, $targetKey);
-			return array();
-		}
-	}
+    return true;
+  }
 
 
-	public function getStorageClass($targetKey) {
-		try {
-			$result = $this->s3Client->listObjects([
-				'Bucket' => $this->bucket,
-				'Prefix'    => $targetKey
-			]);
-			if (!isset($result['Contents'][0]['StorageClass'])) {
-				$this->logging->logError("getStorageClass", "No storage class found", $targetKey);
-				return false;
-			}
-			if ($result['Contents'][0]['StorageClass'] == "GLACIER") {
-				$objectInfo = $this->objectInfo($targetKey);
-				if (strlen($objectInfo['Restore']) > 0) {
-					$explodedInfo = explode(",", $objectInfo['Restore']);
-					if ($explodedInfo[0] == 'ongoing-request="false"') {
-						return "RESTORED";
-					}
-				}
-			}
-			return $result['Contents'][0]['StorageClass'];
-		} catch (Exception $e) {
-			$this->logging->logError("getStorageClass", $e, $targetKey);
-			return false;
-		}
-	}
+  public function putDirectory($sourceDirectory, $destKey, $storageClass = AWS_REDUCED, $job = null) {
+    try {
+      $options["concurrency"] = 50;
+      $this->storageClass = $storageClass;
+      if (!$this->storageClass) {
+        $this->storageClass = AWS_REDUCED;
+      }
 
-	// 'GlacierJobParameters' => [
-	// 'Tier' => 'Expedited'
-	// ]
-	public function restoreObject($targetKey) {
-		try {
-			$result = $this->s3Client->restoreObject([
-				'Bucket' => $this->bucket,
-				'Key'    => $targetKey,
-				'RestoreRequest' => [
-					'Days' => 15,
-					'GlacierJobParameters' => [
-						'Tier' => 'Expedited'
-					]
-				]
-			]);
-		} catch (Aws\S3\Exception\S3Exception $e) {
-			if ($e->getAwsErrorCode() == "GlacierExpeditedRetrievalNotAvailable") {
-				// try again non-expedited
-				try {
-					$result = $this->s3Client->restoreObject([
-						'Bucket' => $this->bucket,
-						'Key'    => $targetKey,
-						'RestoreRequest' => [
-							'Days' => 15,
-						]
-					]);
-				} catch (Aws\S3\Exception\S3Exception $e) {
-					$this->logging->logError("restoreObject", $e->__toString(), $targetKey);
-					return false;
-				}
-			} else {
-				$this->logging->logError("restoreObject", $e->__toString(), $targetKey);
-				return false;
-			}
-		}
-	}
+      $this->transferCount = 0;
+      if ($job) {
+        $this->job = $job;
+      }
+      $beforeFunction = function (Aws\Command $command) {
+        if (in_array($command->getName(), ['PutObject', 'CreateMultipartUpload'])) {
+          // Set custom cache-control metadata
+          // $this->logging->logError("storage class", $this->storageClass);
+          $command['StorageClass'] = $this->storageClass;
+        }
 
-	public function getObjectURL($targetKey) {
-		if (!$this->s3Client) {
-			throw new Exception('Missing object error');
-		}
-		return $this->s3Client->getObjectUrl($this->bucket, $targetKey);
-	}
+        $this->transferCount++;
+        if ($this->transferCount % 100 == 0) {
+          if ($this->pheanstalk !== null && $this->job !== null) {
+            $this->pheanstalk->touch($this->job);
+          }
 
-	public function getProtectedURL($targetKey, $originalName = null, $timeString = "+240 minutes", $forceMimeType = null) {
-		try {
-			$options = array();
+          echo ".";
+        }
+      };
 
-			$options["Bucket"] = $this->bucket;
-			$options["Key"] = $targetKey;
+      if ($beforeFunction) {
+        $options["before"] = $beforeFunction;
+      } else {
+        $options["before"] = function (Aws\Command $command) {
+        };
+      }
+      $destinationPath = "s3://" . $this->bucket . "/" . $destKey;
+      $manager = new \Aws\S3\Transfer($this->s3Client, $sourceDirectory, $destinationPath, $options);
+      $manager->transfer();
+    } catch (Aws\Exception\AwsException $e) {
+      echo $sourceDirectory . "\n";
+      echo $destKey . "\n";
+      $this->logging->logError("uploadDirectory", $e);
+      return false;
+    }
+    return true;
+  }
 
-			if ($originalName) {
-				$originalName = preg_replace('/[^\x20-\x7E]/', '', $originalName);
-				$options["ResponseContentDisposition"] = 'attachment; filename="' . $originalName . '"';
-			} else {
-				// if we don't have an explicit filename, force S3 not to serve one.
-				// we do this mostly because Flash doesn't accept files with a content disposition.
-				$options["ResponseContentDisposition"] = '';
-			}
-			if ($forceMimeType) {
-				$options['ResponseContentType'] = $forceMimeType;
-			}
+  public function getObject($sourceKey, $destFile) {
+    try {
+      $result = $this->s3Client->getObject(array(
+        'Bucket' => $this->bucket,
+        'Key'    => $sourceKey,
+        'SaveAs' => $destFile
+      ));
+    } catch (Exception $e) {
+      $this->logging->logError("getObject", $e, $sourceKey);
+      return false;
+    }
 
-			$cmd = $this->s3Client->getCommand('GetObject', $options);
-			$request = $this->s3Client->createPresignedRequest($cmd, $timeString);
+    return true;
+  }
 
-			return (string)$request->getUri();
-		} catch (Exception $e) {
-			error_log($e);
-			$this->logging->logError("getProtectedURL", $e, $targetKey);
-			return false;
-		}
-	}
+  public function objectInfo($targetKey) {
+    try {
+      $result = $this->s3Client->headObject([
+        'Bucket' => $this->bucket,
+        'Key'    => $targetKey
+      ]);
+      return $result;
+    } catch (Exception $e) {
+      $this->logging->logError("objectInfo", $e->getMessage(), $targetKey);
+      return false;
+    }
+  }
 
+  public function getFilesAtKeyPath($targetKey) {
+    try {
 
-	public function getSecurityTokenForPath($targetKey, $timeSeconds = 3600) {
-		try {
+      $truncated = true;
+      $nextMarker = null;
+      $mergedContents  = array();
+      while ($truncated == true) {
+        $result = $this->s3Client->listObjects([
+          'Bucket' => $this->bucket,
+          'Prefix'    => $targetKey,
+          'Marker' => $nextMarker
+        ]);
 
-			$client = StsClient::factory(array(
-				'region' => 'us-east-1', // TODO should not be hardcoded
-				'version' => '2011-06-15',
-				'credentials' => [
-					'key'    => $this->key,
-					'secret' => $this->secret
-				]
-			));
+        $mergedContents = array_merge($mergedContents, $result['Contents']);
+        if ($result['IsTruncated'] == true) {
+          $lastElement = $result['Contents'][count($result['Contents']) - 1];
+          $nextMarker = $lastElement['Key'];
+        } else {
+          $truncated = false;
+        }
+      }
 
-			$policy = [
-				'Statement' => array(
-					array(
-						'Sid' => 'SID' . time(),
-						'Action' => array(
-							's3:GetObject'
-						),
-						'Effect' => 'Allow',
-						'Resource' => 'arn:aws:s3:::' . $this->bucket . "/" . $targetKey . "*"
-					)
-				)
-			];
-
-			$sessionToken = $client->getFederationToken(["Name" => "policy_" . substr(md5($targetKey), 0, 15), "Policy" => json_encode($policy), "DurationSeconds" => $timeSeconds]);
-
-			return $sessionToken['Credentials'];
-		} catch (Exception $e) {
-			echo $e;
-			$this->logging->logError("getProtectedURL", $e, $targetKey);
-			return false;
-		} catch (\Aws\Sts\Exception\StsException $e) {
-			echo $e;
-			$this->logging->logError("getProtectedURL", $e, $targetKey);
-			return false;
-		}
-	}
+      $fileList = array();
+      foreach ($mergedContents as $entry) {
+        $fileList[] = $entry['Key'];
+      }
+      return $fileList;
+    } catch (Exception $e) {
+      $this->logging->logError("getFilesAtKeyPath", $e, $targetKey);
+      return array();
+    }
+  }
 
 
-	/**
-	 * We have to copy the object to update the metadata
-	 * this should probably preserve other metadta?
-	 * @param [type] $targetKey   [description]
-	 * @param [type] $contentType [description]
-	 */
-	public function setContentType($targetKey, $contentType) {
+  public function getStorageClass($targetKey) {
+    try {
+      $result = $this->s3Client->listObjects([
+        'Bucket' => $this->bucket,
+        'Prefix'    => $targetKey
+      ]);
+      if (!isset($result['Contents'][0]['StorageClass'])) {
+        $this->logging->logError("getStorageClass", "No storage class found", $targetKey);
+        return false;
+      }
+      if ($result['Contents'][0]['StorageClass'] == "GLACIER") {
+        $objectInfo = $this->objectInfo($targetKey);
+        if (strlen($objectInfo['Restore'] ?? '') > 0) {
+          $explodedInfo = explode(",", $objectInfo['Restore']);
+          if ($explodedInfo[0] == 'ongoing-request="false"') {
+            return "RESTORED";
+          }
+        }
+      }
+      return $result['Contents'][0]['StorageClass'];
+    } catch (Exception $e) {
+      $this->logging->logError("getStorageClass", $e, $targetKey);
+      return false;
+    }
+  }
+
+  // 'GlacierJobParameters' => [
+  // 'Tier' => 'Expedited'
+  // ]
+  public function restoreObject($targetKey) {
+    try {
+      $result = $this->s3Client->restoreObject([
+        'Bucket' => $this->bucket,
+        'Key'    => $targetKey,
+        'RestoreRequest' => [
+          'Days' => 15,
+          'GlacierJobParameters' => [
+            'Tier' => 'Expedited'
+          ]
+        ]
+      ]);
+    } catch (Aws\S3\Exception\S3Exception $e) {
+      if ($e->getAwsErrorCode() == "GlacierExpeditedRetrievalNotAvailable") {
+        // try again non-expedited
+        try {
+          $result = $this->s3Client->restoreObject([
+            'Bucket' => $this->bucket,
+            'Key'    => $targetKey,
+            'RestoreRequest' => [
+              'Days' => 15,
+            ]
+          ]);
+        } catch (Aws\S3\Exception\S3Exception $e) {
+          $this->logging->logError("restoreObject", $e->__toString(), $targetKey);
+          return false;
+        }
+      } else {
+        $this->logging->logError("restoreObject", $e->__toString(), $targetKey);
+        return false;
+      }
+    }
+  }
+
+  public function getObjectURL($targetKey) {
+    if (!$this->s3Client) {
+      throw new Exception('Missing object error');
+    }
+    return $this->s3Client->getObjectUrl($this->bucket, $targetKey);
+  }
+
+  public function getProtectedURL($targetKey, $originalName = null, $timeString = "+240 minutes", $forceMimeType = null) {
+    try {
+      $options = array();
+
+      $options["Bucket"] = $this->bucket;
+      $options["Key"] = $targetKey;
+
+      if ($originalName) {
+        $originalName = preg_replace('/[^\x20-\x7E]/', '', $originalName);
+        $options["ResponseContentDisposition"] = 'attachment; filename="' . $originalName . '"';
+      } else {
+        // if we don't have an explicit filename, force S3 not to serve one.
+        // we do this mostly because Flash doesn't accept files with a content disposition.
+        $options["ResponseContentDisposition"] = '';
+      }
+      if ($forceMimeType) {
+        $options['ResponseContentType'] = $forceMimeType;
+      }
+
+      $cmd = $this->s3Client->getCommand('GetObject', $options);
+      $request = $this->s3Client->createPresignedRequest($cmd, $timeString);
+
+      return (string)$request->getUri();
+    } catch (Exception $e) {
+      error_log($e);
+      $this->logging->logError("getProtectedURL", $e, $targetKey);
+      return false;
+    }
+  }
+
+
+  public function getSecurityTokenForPath($targetKey, $timeSeconds = 3600) {
+    try {
+
+      $client = StsClient::factory(array(
+        'region' => 'us-east-1', // TODO should not be hardcoded
+        'version' => '2011-06-15',
+        'credentials' => [
+          'key'    => $this->key,
+          'secret' => $this->secret
+        ]
+      ));
+
+      $policy = [
+        'Statement' => array(
+          array(
+            'Sid' => 'SID' . time(),
+            'Action' => array(
+              's3:GetObject'
+            ),
+            'Effect' => 'Allow',
+            'Resource' => 'arn:aws:s3:::' . $this->bucket . "/" . $targetKey . "*"
+          )
+        )
+      ];
+
+      $sessionToken = $client->getFederationToken(["Name" => "policy_" . substr(md5($targetKey), 0, 15), "Policy" => json_encode($policy), "DurationSeconds" => $timeSeconds]);
+
+      return $sessionToken['Credentials'];
+    } catch (Exception $e) {
+      echo $e;
+      $this->logging->logError("getProtectedURL", $e, $targetKey);
+      return false;
+    } catch (\Aws\Sts\Exception\StsException $e) {
+      echo $e;
+      $this->logging->logError("getProtectedURL", $e, $targetKey);
+      return false;
+    }
+  }
+
+
+  /**
+   * We have to copy the object to update the metadata
+   * this should probably preserve other metadta?
+   * @param [type] $targetKey   [description]
+   * @param [type] $contentType [description]
+   */
+  public function setContentType($targetKey, $contentType) {
 
 
 
-		$iterator = $this->s3Client->getIterator('ListObjects', array(
-			'Bucket' => $this->bucket,
-			'Prefix' => $targetKey
-		));
+    $iterator = $this->s3Client->getIterator('ListObjects', array(
+      'Bucket' => $this->bucket,
+      'Prefix' => $targetKey
+    ));
 
-		foreach ($iterator as $object) {
-			$objectKey = $object['Key'];
-			$metadata = $this->objectInfo($object['Key']);
-			try {
-				$result = $this->s3Client->copyObject([
-					'Bucket' => $this->bucket,
-					'Key'    => $objectKey,
-					'StorageClass'   => $this->getStorageClass($targetKey),
-					'ContentType' => $contentType,
-					'ContentDisposition' => $metadata['ContentDisposition'],
-					'MetadataDirective' => 'REPLACE',
-					'CopySource' => urlencode($this->bucket . "/" . $objectKey)
-				]);
-			} catch (Exception $e) {
-				$this->logging->logError("setContentType", $e, $objectKey);
-			}
-		}
-	}
+    foreach ($iterator as $object) {
+      $objectKey = $object['Key'];
+      $metadata = $this->objectInfo($object['Key']);
+      try {
+        $result = $this->s3Client->copyObject([
+          'Bucket' => $this->bucket,
+          'Key'    => $objectKey,
+          'StorageClass'   => $this->getStorageClass($targetKey),
+          'ContentType' => $contentType,
+          'ContentDisposition' => $metadata['ContentDisposition'],
+          'MetadataDirective' => 'REPLACE',
+          'CopySource' => urlencode($this->bucket . "/" . $objectKey)
+        ]);
+      } catch (Exception $e) {
+        $this->logging->logError("setContentType", $e, $objectKey);
+      }
+    }
+  }
 
-	public function setStorageClass($targetKey, $targetClass) {
-		$iterator = $this->s3Client->getIterator('ListObjects', array(
-			'Bucket' => $this->bucket,
-			'Prefix' => $targetKey
-		));
+  public function setStorageClass($targetKey, $targetClass) {
+    $iterator = $this->s3Client->getIterator('ListObjects', array(
+      'Bucket' => $this->bucket,
+      'Prefix' => $targetKey
+    ));
 
-		foreach ($iterator as $object) {
-			$objectKey = $object['Key'];
-			try {
-				$result = $this->s3Client->copyObject([
-					'Bucket' => $this->bucket,
-					'Key'    => $objectKey,
-					'StorageClass'   => $targetClass,
-					'MetadataDirective' => 'COPY',
-					'CopySource' => urlencode($this->bucket . "/" . $objectKey)
-				]);
-			} catch (Exception $e) {
-				$this->logging->logError("setStorageClass", $e, $objectKey);
-			}
-		}
-	}
+    foreach ($iterator as $object) {
+      $objectKey = $object['Key'];
+      try {
+        $result = $this->s3Client->copyObject([
+          'Bucket' => $this->bucket,
+          'Key'    => $objectKey,
+          'StorageClass'   => $targetClass,
+          'MetadataDirective' => 'COPY',
+          'CopySource' => urlencode($this->bucket . "/" . $objectKey)
+        ]);
+      } catch (Exception $e) {
+        $this->logging->logError("setStorageClass", $e, $objectKey);
+      }
+    }
+  }
 
-	public function deleteObject($targetKey, $serial = null, $mfa = null) {
-		set_time_limit(200);
-		if (strlen($targetKey) < 24) {
-			$this->logging->logError("deleteObject", "Bad or invalid error key", $targetKey);
-			return false;
-		}
+  public function deleteObject($targetKey, $serial = null, $mfa = null) {
+    set_time_limit(200);
+    if (strlen($targetKey) < 24) {
+      $this->logging->logError("deleteObject", "Bad or invalid error key", $targetKey);
+      return false;
+    }
 
-		// Allow environment variables to override stored credentials for CLI operations
-		$awsKey = getenv('AWS_ACCESS_KEY_ID') ?: $this->key;
-		$awsSecret = getenv('AWS_SECRET_ACCESS_KEY') ?: $this->secret;
+    // Allow environment variables to override stored credentials for CLI operations
+    $awsKey = getenv('AWS_ACCESS_KEY_ID') ?: $this->key;
+    $awsSecret = getenv('AWS_SECRET_ACCESS_KEY') ?: $this->secret;
 
-		if (!$serial && !$mfa && $targetKey) {
-			// try to delete the normal way
+    if (!$serial && !$mfa && $targetKey) {
+      // try to delete the normal way
 
-			$this->s3Client = Aws\S3\S3Client::factory(array(
-				'credentials' => [
-					'key'    => $awsKey,
-					'secret' => $awsSecret
-				],
-				"version" => "2006-03-01",
-				"region" => "us-east-1" // TODO: SHOULD NOT BE HARDCODED
-			));
-			$listObjectsParams = ['Bucket' => $this->bucket, 'Prefix' => $targetKey];
-			$delete = Aws\S3\BatchDelete::fromListObjects($this->s3Client, $listObjectsParams);
-			$delete->delete();
-		} else {
-			if (!$this->sessionToken) {
-				try {
-					echo "[DEBUG] About to request session token with serial: $serial\n";
-					$client = StsClient::factory(array(
-						'region' => 'us-east-1', // TODO should not be hardcoded
-						'version' => '2011-06-15',
-						'credentials' => [
-							'key'    => $awsKey,
-							'secret' => $awsSecret
-						]
-					));
-					echo "[DEBUG] STS Client created successfully\n";
-					$this->sessionToken = $client->getSessionToken(["DurationSeconds" => 900, "SerialNumber" => $serial, "TokenCode" => $mfa]);
-					echo "[DEBUG] Session token obtained successfully\n";
-				} catch (\Aws\Exception\AwsException $e) {
-					echo "[CAUGHT AwsException] " . $e->getAwsErrorCode() . ": " . $e->getAwsErrorMessage() . "\n";
-					$this->logging->logError("failed creating token - AwsException", $e->getAwsErrorCode() . ": " . $e->getAwsErrorMessage());
-					return false;
-				} catch (Throwable $e) {
-					echo "[CAUGHT Throwable] " . get_class($e) . ": " . $e->getMessage() . "\n";
-					$this->logging->logError("failed creating token - Throwable", get_class($e) . ": " . $e->getMessage());
-					return false;
-				} catch (Exception $e) {
-					echo "[CAUGHT Exception] " . $e->getMessage() . "\n";
-					$this->logging->logError("failed creating token - Exception", $e->getMessage());
-					return false;
-				}
-			}
-			try {
-				$this->s3Client = Aws\S3\S3Client::factory(array(
-					'credentials' => [
-						'key'    => $this->sessionToken['Credentials']['AccessKeyId'],
-						'secret' => $this->sessionToken['Credentials']['SecretAccessKey'],
-						'token'  => $this->sessionToken['Credentials']['SessionToken']
-					],
-					"version" => "2006-03-01",
-					"region" => "us-east-1" // TODO: SHOULD NOT BE HARDCODED
-				));
-			} catch (Aws\S3\Exception\S3Exception $e) {
-				echo $targetKey;
-				echo $this->bucket;
-				echo "<hr>";
-				echo $e;
-				$this->lgging->logError("failed creating token", $e);
-				return false;
-			}
+      $this->s3Client = Aws\S3\S3Client::factory(array(
+        'credentials' => [
+          'key'    => $awsKey,
+          'secret' => $awsSecret
+        ],
+        "version" => "2006-03-01",
+        "region" => "us-east-1" // TODO: SHOULD NOT BE HARDCODED
+      ));
+      $listObjectsParams = ['Bucket' => $this->bucket, 'Prefix' => $targetKey];
+      $delete = Aws\S3\BatchDelete::fromListObjects($this->s3Client, $listObjectsParams);
+      $delete->delete();
+    } else {
+      if (!$this->sessionToken) {
+        try {
+          echo "[DEBUG] About to request session token with serial: $serial\n";
+          $client = StsClient::factory(array(
+            'region' => 'us-east-1', // TODO should not be hardcoded
+            'version' => '2011-06-15',
+            'credentials' => [
+              'key'    => $awsKey,
+              'secret' => $awsSecret
+            ]
+          ));
+          echo "[DEBUG] STS Client created successfully\n";
+          $this->sessionToken = $client->getSessionToken(["DurationSeconds" => 900, "SerialNumber" => $serial, "TokenCode" => $mfa]);
+          echo "[DEBUG] Session token obtained successfully\n";
+        } catch (\Aws\Exception\AwsException $e) {
+          echo "[CAUGHT AwsException] " . $e->getAwsErrorCode() . ": " . $e->getAwsErrorMessage() . "\n";
+          $this->logging->logError("failed creating token - AwsException", $e->getAwsErrorCode() . ": " . $e->getAwsErrorMessage());
+          return false;
+        } catch (Throwable $e) {
+          echo "[CAUGHT Throwable] " . get_class($e) . ": " . $e->getMessage() . "\n";
+          $this->logging->logError("failed creating token - Throwable", get_class($e) . ": " . $e->getMessage());
+          return false;
+        } catch (Exception $e) {
+          echo "[CAUGHT Exception] " . $e->getMessage() . "\n";
+          $this->logging->logError("failed creating token - Exception", $e->getMessage());
+          return false;
+        }
+      }
+      try {
+        $this->s3Client = Aws\S3\S3Client::factory(array(
+          'credentials' => [
+            'key'    => $this->sessionToken['Credentials']['AccessKeyId'],
+            'secret' => $this->sessionToken['Credentials']['SecretAccessKey'],
+            'token'  => $this->sessionToken['Credentials']['SessionToken']
+          ],
+          "version" => "2006-03-01",
+          "region" => "us-east-1" // TODO: SHOULD NOT BE HARDCODED
+        ));
+      } catch (Aws\S3\Exception\S3Exception $e) {
+        echo $targetKey;
+        echo $this->bucket;
+        echo "<hr>";
+        echo $e;
+        $this->lgging->logError("failed creating token", $e);
+        return false;
+      }
 
 
-			try {
-				if (!$this->bucket) {
-					$this->logging->logError("missing bucket", "missing bucket for " . $targetKey . " " . $this->bucket);
-					return false;
-				}
-				$this->s3Client->deleteMatchingObjects($this->bucket, $targetKey);
-			} catch (Aws\S3\Exception\S3Exception $e) {
-				echo $e;
-				return false;
-			}
-		}
+      try {
+        if (!$this->bucket) {
+          $this->logging->logError("missing bucket", "missing bucket for " . $targetKey . " " . $this->bucket);
+          return false;
+        }
+        $this->s3Client->deleteMatchingObjects($this->bucket, $targetKey);
+      } catch (Aws\S3\Exception\S3Exception $e) {
+        echo $e;
+        return false;
+      }
+    }
 
-		return true;
-	}
+    return true;
+  }
 }
 
 /* End of file  */

--- a/application/models/S3_model.php
+++ b/application/models/S3_model.php
@@ -7,542 +7,542 @@ use Aws\Exception\MultipartUploadException;
 
 class S3_model extends CI_Model {
 
-  public \Aws\S3\S3Client $s3Client;
-  private $secret;
-  private $key;
-  public $bucket;
-  public $sessionToken = null;
-  public $transferCount = 0;
+	public \Aws\S3\S3Client $s3Client;
+	private $secret;
+	private $key;
+	public $bucket;
+	public $sessionToken = null;
+	public $transferCount = 0;
 
-  public function __construct($collection = null) {
-    parent::__construct();
-    if ($collection) {
-      $this->loadFromCollection($collection);
-    }
-  }
+	public function __construct($collection = null) {
+		parent::__construct();
+		if ($collection) {
+			$this->loadFromCollection($collection);
+		}
+	}
 
-  /**
-   * For generating s3 urls (s3://)
-   * @return [type] [description]
-   */
-  public function getSecretKeyPair() {
-    return urlencode(urlencode($this->key)) . ":" . urlencode(urlencode($this->secret));
-  }
+	/**
+	 * For generating s3 urls (s3://)
+	 * @return [type] [description]
+	 */
+	public function getSecretKeyPair() {
+		return urlencode(urlencode($this->key)) . ":" . urlencode(urlencode($this->secret));
+	}
 
-  public function loadFromCollection($collection) {
+	public function loadFromCollection($collection) {
 
-    if (is_numeric($collection)) {
-      $collection = $this->collection_model->getCollection($collection);
-    }
+		if (is_numeric($collection)) {
+			$collection = $this->collection_model->getCollection($collection);
+		}
 
-    $this->secret = $collection->getS3Secret();
-    $this->key = $collection->getS3Key();
-    $this->bucket = $collection->getBucket();
-    $this->s3Client = $this->collection_model->getS3ClientForCollection($collection->getId());
-  }
+		$this->secret = $collection->getS3Secret();
+		$this->key = $collection->getS3Key();
+		$this->bucket = $collection->getBucket();
+		$this->s3Client = $this->collection_model->getS3ClientForCollection($collection->getId());
+	}
 
-  public function loadFromInstance($instance) {
+	public function loadFromInstance($instance) {
 
-    $this->secret = $instance->getAmazonS3Secret();
-    $this->key = $instance->getAmazonS3Key();
-    $this->bucket = $instance->getDefaultBucket();
-    $this->s3Client = $this->s3_model->s3Client =  Aws\S3\S3Client::factory(array(
-      'credentials' => [
-        'key'    => $this->key,
-        'secret' =>  $this->secret
-      ],
-      "scheme" => "https",
-      "version" => "2006-03-01",
-      "use_path_style_endpoint" => true,
-      "region" => $instance->getBucketRegion()
-    ));
-  }
+		$this->secret = $instance->getAmazonS3Secret();
+		$this->key = $instance->getAmazonS3Key();
+		$this->bucket = $instance->getDefaultBucket();
+		$this->s3Client = $this->s3_model->s3Client =  Aws\S3\S3Client::factory(array(
+			'credentials' => [
+				'key'    => $this->key,
+				'secret' =>  $this->secret
+			],
+			"scheme" => "https",
+			"version" => "2006-03-01",
+			"use_path_style_endpoint" => true,
+			"region" => $instance->getBucketRegion()
+		));
+	}
 
-  public function fixACL($sourceFile) {
-    if (strlen($this->bucket) < 5) {
-      echo "Error: bucket unknown\n";
-      throw new Exception('Bucket Error');
-    }
+	public function fixACL($sourceFile) {
+		if (strlen($this->bucket) < 5) {
+			echo "Error: bucket unknown\n";
+			throw new Exception('Bucket Error');
+		}
 
-    $command = [
-      'ACL' => 'private',
-      'Bucket' => $this->bucket,
-      'Key' => "original/" . strrev($sourceFile) . "-source"
-    ];
-    try {
-      $this->s3Client->putObjectAcl($command);
-    } catch (Aws\S3\Exception\S3Exception $e) {
-      var_dump($command);
-      echo $e->getAwsErrorType() . "\n";
-      echo $e->getAwsErrorCode() . "\n";
-      throw new Exception('Error setting ACL');
-    }
-  }
+		$command = [
+			'ACL' => 'private',
+			'Bucket' => $this->bucket,
+			'Key' => "original/" . strrev($sourceFile) . "-source"
+		];
+		try {
+			$this->s3Client->putObjectAcl($command);
+		} catch (Aws\S3\Exception\S3Exception $e) {
+			var_dump($command);
+			echo $e->getAwsErrorType() . "\n";
+			echo $e->getAwsErrorCode() . "\n";
+			throw new Exception('Error setting ACL');
+		}
+	}
 
-  public function putObject($sourceFile, $destKey, $storageClass = AWS_REDUCED, $targetMimeType = null, $contentEncoding = null) {
-    if (!file_exists($sourceFile)) {
-      $this->logging->logError("putObject", "file no longer exists", $sourceFile);
-      return false;
-    }
+	public function putObject($sourceFile, $destKey, $storageClass = AWS_REDUCED, $targetMimeType = null, $contentEncoding = null) {
+		if (!file_exists($sourceFile)) {
+			$this->logging->logError("putObject", "file no longer exists", $sourceFile);
+			return false;
+		}
 
-    if (!$targetMimeType) {
-      $targetMimeType = mime_content_type($sourceFile);
-    }
+		if (!$targetMimeType) {
+			$targetMimeType = mime_content_type($sourceFile);
+		}
 
-    if (filesize($sourceFile) < 100 * 1024 * 1024) {
-      try {
-        $fp = fopen($sourceFile, "rb");
-        $this->s3Client->putObject(array(
-          'Bucket' => $this->bucket,
-          'Key'    => $destKey,
-          'Body'   => $fp,
-          'StorageClass'   => $storageClass,
-          "ContentType" => $targetMimeType,
-          "ContentEncoding" => $contentEncoding
-        ));
-        fclose($fp);
-      } catch (Exception $e) {
-        $this->logging->logError("putObject", $e, $sourceFile);
-        return false;
-      } catch (\Aws\S3\Exception\S3Exception $e) {
-        $this->logging->logError("putObject", $e, $sourceFile);
-        return false;
-      }
-    } else {
+		if (filesize($sourceFile) < 100 * 1024 * 1024) {
+			try {
+				$fp = fopen($sourceFile, "rb");
+				$this->s3Client->putObject(array(
+					'Bucket' => $this->bucket,
+					'Key'    => $destKey,
+					'Body'   => $fp,
+					'StorageClass'   => $storageClass,
+					"ContentType" => $targetMimeType,
+					"ContentEncoding" => $contentEncoding
+				));
+				fclose($fp);
+			} catch (Exception $e) {
+				$this->logging->logError("putObject", $e, $sourceFile);
+				return false;
+			} catch (\Aws\S3\Exception\S3Exception $e) {
+				$this->logging->logError("putObject", $e, $sourceFile);
+				return false;
+			}
+		} else {
 
-      $this->transferCount = 0;
-      $beforeFunction = function (Aws\Command $command) {
-        $this->transferCount++;
-        if ($this->transferCount % 10 == 0) {
-          if (@$this->pheanstalk !== null && @$this->job !== null) {
-            $this->pheanstalk->touch($this->job);
-          }
-        }
-      };
+			$this->transferCount = 0;
+			$beforeFunction = function (Aws\Command $command) {
+				$this->transferCount++;
+				if ($this->transferCount % 10 == 0) {
+					if (@$this->pheanstalk !== null && @$this->job !== null) {
+						$this->pheanstalk->touch($this->job);
+					}
+				}
+			};
 
-      $uploader = new \Aws\S3\MultipartUploader($this->s3Client, $sourceFile, [
-        'bucket' => $this->bucket,
-        'key'    => $destKey,
-        'before_initiate' => function (\Aws\Command $command) use ($targetMimeType, $storageClass)  //  HERE IS THE RELEVANT CODE
-        {
-          $command['ContentType'] = $targetMimeType;
-          $command['StorageClass'] = $storageClass;
-        },
-        "before_upload" => $beforeFunction
-      ]);
+			$uploader = new \Aws\S3\MultipartUploader($this->s3Client, $sourceFile, [
+				'bucket' => $this->bucket,
+				'key'    => $destKey,
+				'before_initiate' => function (\Aws\Command $command) use ($targetMimeType, $storageClass)  //  HERE IS THE RELEVANT CODE
+				{
+					$command['ContentType'] = $targetMimeType;
+					$command['StorageClass'] = $storageClass;
+				},
+				"before_upload" => $beforeFunction
+			]);
 
-      do {
-        try {
-          $result = $uploader->upload();
-        } catch (MultipartUploadException $e) {
-          $uploader = new \Aws\S3\MultipartUploader($this->s3Client, $sourceFile, [
-            'state' => $e->getState(),
-          ]);
-        }
-      } while (!isset($result));
+			do {
+				try {
+					$result = $uploader->upload();
+				} catch (MultipartUploadException $e) {
+					$uploader = new \Aws\S3\MultipartUploader($this->s3Client, $sourceFile, [
+						'state' => $e->getState(),
+					]);
+				}
+			} while (!isset($result));
 
-      return $result ? true : false;
-    }
-
-
-    return true;
-  }
+			return $result ? true : false;
+		}
 
 
-  public function putDirectory($sourceDirectory, $destKey, $storageClass = AWS_REDUCED, $job = null) {
-    try {
-      $options["concurrency"] = 50;
-      $this->storageClass = $storageClass;
-      if (!$this->storageClass) {
-        $this->storageClass = AWS_REDUCED;
-      }
-
-      $this->transferCount = 0;
-      if ($job) {
-        $this->job = $job;
-      }
-      $beforeFunction = function (Aws\Command $command) {
-        if (in_array($command->getName(), ['PutObject', 'CreateMultipartUpload'])) {
-          // Set custom cache-control metadata
-          // $this->logging->logError("storage class", $this->storageClass);
-          $command['StorageClass'] = $this->storageClass;
-        }
-
-        $this->transferCount++;
-        if ($this->transferCount % 100 == 0) {
-          if ($this->pheanstalk !== null && $this->job !== null) {
-            $this->pheanstalk->touch($this->job);
-          }
-
-          echo ".";
-        }
-      };
-
-      if ($beforeFunction) {
-        $options["before"] = $beforeFunction;
-      } else {
-        $options["before"] = function (Aws\Command $command) {
-        };
-      }
-      $destinationPath = "s3://" . $this->bucket . "/" . $destKey;
-      $manager = new \Aws\S3\Transfer($this->s3Client, $sourceDirectory, $destinationPath, $options);
-      $manager->transfer();
-    } catch (Aws\Exception\AwsException $e) {
-      echo $sourceDirectory . "\n";
-      echo $destKey . "\n";
-      $this->logging->logError("uploadDirectory", $e);
-      return false;
-    }
-    return true;
-  }
-
-  public function getObject($sourceKey, $destFile) {
-    try {
-      $result = $this->s3Client->getObject(array(
-        'Bucket' => $this->bucket,
-        'Key'    => $sourceKey,
-        'SaveAs' => $destFile
-      ));
-    } catch (Exception $e) {
-      $this->logging->logError("getObject", $e, $sourceKey);
-      return false;
-    }
-
-    return true;
-  }
-
-  public function objectInfo($targetKey) {
-    try {
-      $result = $this->s3Client->headObject([
-        'Bucket' => $this->bucket,
-        'Key'    => $targetKey
-      ]);
-      return $result;
-    } catch (Exception $e) {
-      $this->logging->logError("objectInfo", $e->getMessage(), $targetKey);
-      return false;
-    }
-  }
-
-  public function getFilesAtKeyPath($targetKey) {
-    try {
-
-      $truncated = true;
-      $nextMarker = null;
-      $mergedContents  = array();
-      while ($truncated == true) {
-        $result = $this->s3Client->listObjects([
-          'Bucket' => $this->bucket,
-          'Prefix'    => $targetKey,
-          'Marker' => $nextMarker
-        ]);
-
-        $mergedContents = array_merge($mergedContents, $result['Contents']);
-        if ($result['IsTruncated'] == true) {
-          $lastElement = $result['Contents'][count($result['Contents']) - 1];
-          $nextMarker = $lastElement['Key'];
-        } else {
-          $truncated = false;
-        }
-      }
-
-      $fileList = array();
-      foreach ($mergedContents as $entry) {
-        $fileList[] = $entry['Key'];
-      }
-      return $fileList;
-    } catch (Exception $e) {
-      $this->logging->logError("getFilesAtKeyPath", $e, $targetKey);
-      return array();
-    }
-  }
+		return true;
+	}
 
 
-  public function getStorageClass($targetKey) {
-    try {
-      $result = $this->s3Client->listObjects([
-        'Bucket' => $this->bucket,
-        'Prefix'    => $targetKey
-      ]);
-      if (!isset($result['Contents'][0]['StorageClass'])) {
-        $this->logging->logError("getStorageClass", "No storage class found", $targetKey);
-        return false;
-      }
-      if ($result['Contents'][0]['StorageClass'] == "GLACIER") {
-        $objectInfo = $this->objectInfo($targetKey);
-        if (strlen($objectInfo['Restore'] ?? '') > 0) {
-          $explodedInfo = explode(",", $objectInfo['Restore']);
-          if ($explodedInfo[0] == 'ongoing-request="false"') {
-            return "RESTORED";
-          }
-        }
-      }
-      return $result['Contents'][0]['StorageClass'];
-    } catch (Exception $e) {
-      $this->logging->logError("getStorageClass", $e, $targetKey);
-      return false;
-    }
-  }
+	public function putDirectory($sourceDirectory, $destKey, $storageClass = AWS_REDUCED, $job = null) {
+		try {
+			$options["concurrency"] = 50;
+			$this->storageClass = $storageClass;
+			if (!$this->storageClass) {
+				$this->storageClass = AWS_REDUCED;
+			}
 
-  // 'GlacierJobParameters' => [
-  // 'Tier' => 'Expedited'
-  // ]
-  public function restoreObject($targetKey) {
-    try {
-      $result = $this->s3Client->restoreObject([
-        'Bucket' => $this->bucket,
-        'Key'    => $targetKey,
-        'RestoreRequest' => [
-          'Days' => 15,
-          'GlacierJobParameters' => [
-            'Tier' => 'Expedited'
-          ]
-        ]
-      ]);
-    } catch (Aws\S3\Exception\S3Exception $e) {
-      if ($e->getAwsErrorCode() == "GlacierExpeditedRetrievalNotAvailable") {
-        // try again non-expedited
-        try {
-          $result = $this->s3Client->restoreObject([
-            'Bucket' => $this->bucket,
-            'Key'    => $targetKey,
-            'RestoreRequest' => [
-              'Days' => 15,
-            ]
-          ]);
-        } catch (Aws\S3\Exception\S3Exception $e) {
-          $this->logging->logError("restoreObject", $e->__toString(), $targetKey);
-          return false;
-        }
-      } else {
-        $this->logging->logError("restoreObject", $e->__toString(), $targetKey);
-        return false;
-      }
-    }
-  }
+			$this->transferCount = 0;
+			if ($job) {
+				$this->job = $job;
+			}
+			$beforeFunction = function (Aws\Command $command) {
+				if (in_array($command->getName(), ['PutObject', 'CreateMultipartUpload'])) {
+					// Set custom cache-control metadata
+					// $this->logging->logError("storage class", $this->storageClass);
+					$command['StorageClass'] = $this->storageClass;
+				}
 
-  public function getObjectURL($targetKey) {
-    if (!$this->s3Client) {
-      throw new Exception('Missing object error');
-    }
-    return $this->s3Client->getObjectUrl($this->bucket, $targetKey);
-  }
+				$this->transferCount++;
+				if ($this->transferCount % 100 == 0) {
+					if ($this->pheanstalk !== null && $this->job !== null) {
+						$this->pheanstalk->touch($this->job);
+					}
 
-  public function getProtectedURL($targetKey, $originalName = null, $timeString = "+240 minutes", $forceMimeType = null) {
-    try {
-      $options = array();
+					echo ".";
+				}
+			};
 
-      $options["Bucket"] = $this->bucket;
-      $options["Key"] = $targetKey;
+			if ($beforeFunction) {
+				$options["before"] = $beforeFunction;
+			} else {
+				$options["before"] = function (Aws\Command $command) {
+				};
+			}
+			$destinationPath = "s3://" . $this->bucket . "/" . $destKey;
+			$manager = new \Aws\S3\Transfer($this->s3Client, $sourceDirectory, $destinationPath, $options);
+			$manager->transfer();
+		} catch (Aws\Exception\AwsException $e) {
+			echo $sourceDirectory . "\n";
+			echo $destKey . "\n";
+			$this->logging->logError("uploadDirectory", $e);
+			return false;
+		}
+		return true;
+	}
 
-      if ($originalName) {
-        $originalName = preg_replace('/[^\x20-\x7E]/', '', $originalName);
-        $options["ResponseContentDisposition"] = 'attachment; filename="' . $originalName . '"';
-      } else {
-        // if we don't have an explicit filename, force S3 not to serve one.
-        // we do this mostly because Flash doesn't accept files with a content disposition.
-        $options["ResponseContentDisposition"] = '';
-      }
-      if ($forceMimeType) {
-        $options['ResponseContentType'] = $forceMimeType;
-      }
+	public function getObject($sourceKey, $destFile) {
+		try {
+			$result = $this->s3Client->getObject(array(
+				'Bucket' => $this->bucket,
+				'Key'    => $sourceKey,
+				'SaveAs' => $destFile
+			));
+		} catch (Exception $e) {
+			$this->logging->logError("getObject", $e, $sourceKey);
+			return false;
+		}
 
-      $cmd = $this->s3Client->getCommand('GetObject', $options);
-      $request = $this->s3Client->createPresignedRequest($cmd, $timeString);
+		return true;
+	}
 
-      return (string)$request->getUri();
-    } catch (Exception $e) {
-      error_log($e);
-      $this->logging->logError("getProtectedURL", $e, $targetKey);
-      return false;
-    }
-  }
+	public function objectInfo($targetKey) {
+		try {
+			$result = $this->s3Client->headObject([
+				'Bucket' => $this->bucket,
+				'Key'    => $targetKey
+			]);
+			return $result;
+		} catch (Exception $e) {
+			$this->logging->logError("objectInfo", $e->getMessage(), $targetKey);
+			return false;
+		}
+	}
 
+	public function getFilesAtKeyPath($targetKey) {
+		try {
 
-  public function getSecurityTokenForPath($targetKey, $timeSeconds = 3600) {
-    try {
+			$truncated = true;
+			$nextMarker = null;
+			$mergedContents  = array();
+			while ($truncated == true) {
+				$result = $this->s3Client->listObjects([
+					'Bucket' => $this->bucket,
+					'Prefix'    => $targetKey,
+					'Marker' => $nextMarker
+				]);
 
-      $client = StsClient::factory(array(
-        'region' => 'us-east-1', // TODO should not be hardcoded
-        'version' => '2011-06-15',
-        'credentials' => [
-          'key'    => $this->key,
-          'secret' => $this->secret
-        ]
-      ));
+				$mergedContents = array_merge($mergedContents, $result['Contents']);
+				if ($result['IsTruncated'] == true) {
+					$lastElement = $result['Contents'][count($result['Contents']) - 1];
+					$nextMarker = $lastElement['Key'];
+				} else {
+					$truncated = false;
+				}
+			}
 
-      $policy = [
-        'Statement' => array(
-          array(
-            'Sid' => 'SID' . time(),
-            'Action' => array(
-              's3:GetObject'
-            ),
-            'Effect' => 'Allow',
-            'Resource' => 'arn:aws:s3:::' . $this->bucket . "/" . $targetKey . "*"
-          )
-        )
-      ];
-
-      $sessionToken = $client->getFederationToken(["Name" => "policy_" . substr(md5($targetKey), 0, 15), "Policy" => json_encode($policy), "DurationSeconds" => $timeSeconds]);
-
-      return $sessionToken['Credentials'];
-    } catch (Exception $e) {
-      echo $e;
-      $this->logging->logError("getProtectedURL", $e, $targetKey);
-      return false;
-    } catch (\Aws\Sts\Exception\StsException $e) {
-      echo $e;
-      $this->logging->logError("getProtectedURL", $e, $targetKey);
-      return false;
-    }
-  }
+			$fileList = array();
+			foreach ($mergedContents as $entry) {
+				$fileList[] = $entry['Key'];
+			}
+			return $fileList;
+		} catch (Exception $e) {
+			$this->logging->logError("getFilesAtKeyPath", $e, $targetKey);
+			return array();
+		}
+	}
 
 
-  /**
-   * We have to copy the object to update the metadata
-   * this should probably preserve other metadta?
-   * @param [type] $targetKey   [description]
-   * @param [type] $contentType [description]
-   */
-  public function setContentType($targetKey, $contentType) {
+	public function getStorageClass($targetKey) {
+		try {
+			$result = $this->s3Client->listObjects([
+				'Bucket' => $this->bucket,
+				'Prefix'    => $targetKey
+			]);
+			if (!isset($result['Contents'][0]['StorageClass'])) {
+				$this->logging->logError("getStorageClass", "No storage class found", $targetKey);
+				return false;
+			}
+			if ($result['Contents'][0]['StorageClass'] == "GLACIER") {
+				$objectInfo = $this->objectInfo($targetKey);
+				if (strlen($objectInfo['Restore'] ?? "") > 0) {
+					$explodedInfo = explode(",", $objectInfo['Restore']);
+					if ($explodedInfo[0] == 'ongoing-request="false"') {
+						return "RESTORED";
+					}
+				}
+			}
+			return $result['Contents'][0]['StorageClass'];
+		} catch (Exception $e) {
+			$this->logging->logError("getStorageClass", $e, $targetKey);
+			return false;
+		}
+	}
+
+	// 'GlacierJobParameters' => [
+	// 'Tier' => 'Expedited'
+	// ]
+	public function restoreObject($targetKey) {
+		try {
+			$result = $this->s3Client->restoreObject([
+				'Bucket' => $this->bucket,
+				'Key'    => $targetKey,
+				'RestoreRequest' => [
+					'Days' => 15,
+					'GlacierJobParameters' => [
+						'Tier' => 'Expedited'
+					]
+				]
+			]);
+		} catch (Aws\S3\Exception\S3Exception $e) {
+			if ($e->getAwsErrorCode() == "GlacierExpeditedRetrievalNotAvailable") {
+				// try again non-expedited
+				try {
+					$result = $this->s3Client->restoreObject([
+						'Bucket' => $this->bucket,
+						'Key'    => $targetKey,
+						'RestoreRequest' => [
+							'Days' => 15,
+						]
+					]);
+				} catch (Aws\S3\Exception\S3Exception $e) {
+					$this->logging->logError("restoreObject", $e->__toString(), $targetKey);
+					return false;
+				}
+			} else {
+				$this->logging->logError("restoreObject", $e->__toString(), $targetKey);
+				return false;
+			}
+		}
+	}
+
+	public function getObjectURL($targetKey) {
+		if (!$this->s3Client) {
+			throw new Exception('Missing object error');
+		}
+		return $this->s3Client->getObjectUrl($this->bucket, $targetKey);
+	}
+
+	public function getProtectedURL($targetKey, $originalName = null, $timeString = "+240 minutes", $forceMimeType = null) {
+		try {
+			$options = array();
+
+			$options["Bucket"] = $this->bucket;
+			$options["Key"] = $targetKey;
+
+			if ($originalName) {
+				$originalName = preg_replace('/[^\x20-\x7E]/', '', $originalName);
+				$options["ResponseContentDisposition"] = 'attachment; filename="' . $originalName . '"';
+			} else {
+				// if we don't have an explicit filename, force S3 not to serve one.
+				// we do this mostly because Flash doesn't accept files with a content disposition.
+				$options["ResponseContentDisposition"] = '';
+			}
+			if ($forceMimeType) {
+				$options['ResponseContentType'] = $forceMimeType;
+			}
+
+			$cmd = $this->s3Client->getCommand('GetObject', $options);
+			$request = $this->s3Client->createPresignedRequest($cmd, $timeString);
+
+			return (string)$request->getUri();
+		} catch (Exception $e) {
+			error_log($e);
+			$this->logging->logError("getProtectedURL", $e, $targetKey);
+			return false;
+		}
+	}
+
+
+	public function getSecurityTokenForPath($targetKey, $timeSeconds = 3600) {
+		try {
+
+			$client = StsClient::factory(array(
+				'region' => 'us-east-1', // TODO should not be hardcoded
+				'version' => '2011-06-15',
+				'credentials' => [
+					'key'    => $this->key,
+					'secret' => $this->secret
+				]
+			));
+
+			$policy = [
+				'Statement' => array(
+					array(
+						'Sid' => 'SID' . time(),
+						'Action' => array(
+							's3:GetObject'
+						),
+						'Effect' => 'Allow',
+						'Resource' => 'arn:aws:s3:::' . $this->bucket . "/" . $targetKey . "*"
+					)
+				)
+			];
+
+			$sessionToken = $client->getFederationToken(["Name" => "policy_" . substr(md5($targetKey), 0, 15), "Policy" => json_encode($policy), "DurationSeconds" => $timeSeconds]);
+
+			return $sessionToken['Credentials'];
+		} catch (Exception $e) {
+			echo $e;
+			$this->logging->logError("getProtectedURL", $e, $targetKey);
+			return false;
+		} catch (\Aws\Sts\Exception\StsException $e) {
+			echo $e;
+			$this->logging->logError("getProtectedURL", $e, $targetKey);
+			return false;
+		}
+	}
+
+
+	/**
+	 * We have to copy the object to update the metadata
+	 * this should probably preserve other metadta?
+	 * @param [type] $targetKey   [description]
+	 * @param [type] $contentType [description]
+	 */
+	public function setContentType($targetKey, $contentType) {
 
 
 
-    $iterator = $this->s3Client->getIterator('ListObjects', array(
-      'Bucket' => $this->bucket,
-      'Prefix' => $targetKey
-    ));
+		$iterator = $this->s3Client->getIterator('ListObjects', array(
+			'Bucket' => $this->bucket,
+			'Prefix' => $targetKey
+		));
 
-    foreach ($iterator as $object) {
-      $objectKey = $object['Key'];
-      $metadata = $this->objectInfo($object['Key']);
-      try {
-        $result = $this->s3Client->copyObject([
-          'Bucket' => $this->bucket,
-          'Key'    => $objectKey,
-          'StorageClass'   => $this->getStorageClass($targetKey),
-          'ContentType' => $contentType,
-          'ContentDisposition' => $metadata['ContentDisposition'],
-          'MetadataDirective' => 'REPLACE',
-          'CopySource' => urlencode($this->bucket . "/" . $objectKey)
-        ]);
-      } catch (Exception $e) {
-        $this->logging->logError("setContentType", $e, $objectKey);
-      }
-    }
-  }
+		foreach ($iterator as $object) {
+			$objectKey = $object['Key'];
+			$metadata = $this->objectInfo($object['Key']);
+			try {
+				$result = $this->s3Client->copyObject([
+					'Bucket' => $this->bucket,
+					'Key'    => $objectKey,
+					'StorageClass'   => $this->getStorageClass($targetKey),
+					'ContentType' => $contentType,
+					'ContentDisposition' => $metadata['ContentDisposition'],
+					'MetadataDirective' => 'REPLACE',
+					'CopySource' => urlencode($this->bucket . "/" . $objectKey)
+				]);
+			} catch (Exception $e) {
+				$this->logging->logError("setContentType", $e, $objectKey);
+			}
+		}
+	}
 
-  public function setStorageClass($targetKey, $targetClass) {
-    $iterator = $this->s3Client->getIterator('ListObjects', array(
-      'Bucket' => $this->bucket,
-      'Prefix' => $targetKey
-    ));
+	public function setStorageClass($targetKey, $targetClass) {
+		$iterator = $this->s3Client->getIterator('ListObjects', array(
+			'Bucket' => $this->bucket,
+			'Prefix' => $targetKey
+		));
 
-    foreach ($iterator as $object) {
-      $objectKey = $object['Key'];
-      try {
-        $result = $this->s3Client->copyObject([
-          'Bucket' => $this->bucket,
-          'Key'    => $objectKey,
-          'StorageClass'   => $targetClass,
-          'MetadataDirective' => 'COPY',
-          'CopySource' => urlencode($this->bucket . "/" . $objectKey)
-        ]);
-      } catch (Exception $e) {
-        $this->logging->logError("setStorageClass", $e, $objectKey);
-      }
-    }
-  }
+		foreach ($iterator as $object) {
+			$objectKey = $object['Key'];
+			try {
+				$result = $this->s3Client->copyObject([
+					'Bucket' => $this->bucket,
+					'Key'    => $objectKey,
+					'StorageClass'   => $targetClass,
+					'MetadataDirective' => 'COPY',
+					'CopySource' => urlencode($this->bucket . "/" . $objectKey)
+				]);
+			} catch (Exception $e) {
+				$this->logging->logError("setStorageClass", $e, $objectKey);
+			}
+		}
+	}
 
-  public function deleteObject($targetKey, $serial = null, $mfa = null) {
-    set_time_limit(200);
-    if (strlen($targetKey) < 24) {
-      $this->logging->logError("deleteObject", "Bad or invalid error key", $targetKey);
-      return false;
-    }
+	public function deleteObject($targetKey, $serial = null, $mfa = null) {
+		set_time_limit(200);
+		if (strlen($targetKey) < 24) {
+			$this->logging->logError("deleteObject", "Bad or invalid error key", $targetKey);
+			return false;
+		}
 
-    // Allow environment variables to override stored credentials for CLI operations
-    $awsKey = getenv('AWS_ACCESS_KEY_ID') ?: $this->key;
-    $awsSecret = getenv('AWS_SECRET_ACCESS_KEY') ?: $this->secret;
+		// Allow environment variables to override stored credentials for CLI operations
+		$awsKey = getenv('AWS_ACCESS_KEY_ID') ?: $this->key;
+		$awsSecret = getenv('AWS_SECRET_ACCESS_KEY') ?: $this->secret;
 
-    if (!$serial && !$mfa && $targetKey) {
-      // try to delete the normal way
+		if (!$serial && !$mfa && $targetKey) {
+			// try to delete the normal way
 
-      $this->s3Client = Aws\S3\S3Client::factory(array(
-        'credentials' => [
-          'key'    => $awsKey,
-          'secret' => $awsSecret
-        ],
-        "version" => "2006-03-01",
-        "region" => "us-east-1" // TODO: SHOULD NOT BE HARDCODED
-      ));
-      $listObjectsParams = ['Bucket' => $this->bucket, 'Prefix' => $targetKey];
-      $delete = Aws\S3\BatchDelete::fromListObjects($this->s3Client, $listObjectsParams);
-      $delete->delete();
-    } else {
-      if (!$this->sessionToken) {
-        try {
-          echo "[DEBUG] About to request session token with serial: $serial\n";
-          $client = StsClient::factory(array(
-            'region' => 'us-east-1', // TODO should not be hardcoded
-            'version' => '2011-06-15',
-            'credentials' => [
-              'key'    => $awsKey,
-              'secret' => $awsSecret
-            ]
-          ));
-          echo "[DEBUG] STS Client created successfully\n";
-          $this->sessionToken = $client->getSessionToken(["DurationSeconds" => 900, "SerialNumber" => $serial, "TokenCode" => $mfa]);
-          echo "[DEBUG] Session token obtained successfully\n";
-        } catch (\Aws\Exception\AwsException $e) {
-          echo "[CAUGHT AwsException] " . $e->getAwsErrorCode() . ": " . $e->getAwsErrorMessage() . "\n";
-          $this->logging->logError("failed creating token - AwsException", $e->getAwsErrorCode() . ": " . $e->getAwsErrorMessage());
-          return false;
-        } catch (Throwable $e) {
-          echo "[CAUGHT Throwable] " . get_class($e) . ": " . $e->getMessage() . "\n";
-          $this->logging->logError("failed creating token - Throwable", get_class($e) . ": " . $e->getMessage());
-          return false;
-        } catch (Exception $e) {
-          echo "[CAUGHT Exception] " . $e->getMessage() . "\n";
-          $this->logging->logError("failed creating token - Exception", $e->getMessage());
-          return false;
-        }
-      }
-      try {
-        $this->s3Client = Aws\S3\S3Client::factory(array(
-          'credentials' => [
-            'key'    => $this->sessionToken['Credentials']['AccessKeyId'],
-            'secret' => $this->sessionToken['Credentials']['SecretAccessKey'],
-            'token'  => $this->sessionToken['Credentials']['SessionToken']
-          ],
-          "version" => "2006-03-01",
-          "region" => "us-east-1" // TODO: SHOULD NOT BE HARDCODED
-        ));
-      } catch (Aws\S3\Exception\S3Exception $e) {
-        echo $targetKey;
-        echo $this->bucket;
-        echo "<hr>";
-        echo $e;
-        $this->lgging->logError("failed creating token", $e);
-        return false;
-      }
+			$this->s3Client = Aws\S3\S3Client::factory(array(
+				'credentials' => [
+					'key'    => $awsKey,
+					'secret' => $awsSecret
+				],
+				"version" => "2006-03-01",
+				"region" => "us-east-1" // TODO: SHOULD NOT BE HARDCODED
+			));
+			$listObjectsParams = ['Bucket' => $this->bucket, 'Prefix' => $targetKey];
+			$delete = Aws\S3\BatchDelete::fromListObjects($this->s3Client, $listObjectsParams);
+			$delete->delete();
+		} else {
+			if (!$this->sessionToken) {
+				try {
+					echo "[DEBUG] About to request session token with serial: $serial\n";
+					$client = StsClient::factory(array(
+						'region' => 'us-east-1', // TODO should not be hardcoded
+						'version' => '2011-06-15',
+						'credentials' => [
+							'key'    => $awsKey,
+							'secret' => $awsSecret
+						]
+					));
+					echo "[DEBUG] STS Client created successfully\n";
+					$this->sessionToken = $client->getSessionToken(["DurationSeconds" => 900, "SerialNumber" => $serial, "TokenCode" => $mfa]);
+					echo "[DEBUG] Session token obtained successfully\n";
+				} catch (\Aws\Exception\AwsException $e) {
+					echo "[CAUGHT AwsException] " . $e->getAwsErrorCode() . ": " . $e->getAwsErrorMessage() . "\n";
+					$this->logging->logError("failed creating token - AwsException", $e->getAwsErrorCode() . ": " . $e->getAwsErrorMessage());
+					return false;
+				} catch (Throwable $e) {
+					echo "[CAUGHT Throwable] " . get_class($e) . ": " . $e->getMessage() . "\n";
+					$this->logging->logError("failed creating token - Throwable", get_class($e) . ": " . $e->getMessage());
+					return false;
+				} catch (Exception $e) {
+					echo "[CAUGHT Exception] " . $e->getMessage() . "\n";
+					$this->logging->logError("failed creating token - Exception", $e->getMessage());
+					return false;
+				}
+			}
+			try {
+				$this->s3Client = Aws\S3\S3Client::factory(array(
+					'credentials' => [
+						'key'    => $this->sessionToken['Credentials']['AccessKeyId'],
+						'secret' => $this->sessionToken['Credentials']['SecretAccessKey'],
+						'token'  => $this->sessionToken['Credentials']['SessionToken']
+					],
+					"version" => "2006-03-01",
+					"region" => "us-east-1" // TODO: SHOULD NOT BE HARDCODED
+				));
+			} catch (Aws\S3\Exception\S3Exception $e) {
+				echo $targetKey;
+				echo $this->bucket;
+				echo "<hr>";
+				echo $e;
+				$this->lgging->logError("failed creating token", $e);
+				return false;
+			}
 
 
-      try {
-        if (!$this->bucket) {
-          $this->logging->logError("missing bucket", "missing bucket for " . $targetKey . " " . $this->bucket);
-          return false;
-        }
-        $this->s3Client->deleteMatchingObjects($this->bucket, $targetKey);
-      } catch (Aws\S3\Exception\S3Exception $e) {
-        echo $e;
-        return false;
-      }
-    }
+			try {
+				if (!$this->bucket) {
+					$this->logging->logError("missing bucket", "missing bucket for " . $targetKey . " " . $this->bucket);
+					return false;
+				}
+				$this->s3Client->deleteMatchingObjects($this->bucket, $targetKey);
+			} catch (Aws\S3\Exception\S3Exception $e) {
+				echo $e;
+				return false;
+			}
+		}
 
-    return true;
-  }
+		return true;
+	}
 }
 
 /* End of file  */

--- a/application/models/S3_model.php
+++ b/application/models/S3_model.php
@@ -7,7 +7,7 @@ use Aws\Exception\MultipartUploadException;
 
 class S3_model extends CI_Model {
 
-	public $s3Client;
+	public \Aws\S3\S3Client $s3Client;
 	private $secret;
 	private $key;
 	public $bucket;

--- a/application/models/filehandlers/Filehandlerbase.php
+++ b/application/models/filehandlers/Filehandlerbase.php
@@ -11,6 +11,24 @@ use Aws\Exception\AwsException;
 if ( ! defined('BASEPATH')) exit('No direct script access allowed');
 
 
+/**
+ * Base class for file handlers — wraps an asset's source file, manages its
+ * derivatives, and queues the processing tasks that build them.
+ *
+ * The @property tags cover CodeIgniter's magic loader properties so that
+ * command-click and autocomplete resolve on them.
+ *
+ * @property CI_Loader $load
+ * @property CI_Config $config
+ * @property CI_Cache $cache
+ * @property Doctrine $doctrine
+ * @property Logging $logging
+ * @property \Entity\Instance $instance
+ * @property Filehandler_router $filehandler_router
+ * @property Asset_model $asset_model
+ * @property User_model $user_model
+ * @property collection_model $collection_model
+ */
 class FileHandlerBase extends CI_Model {
 
 	/**
@@ -30,13 +48,13 @@ class FileHandlerBase extends CI_Model {
 	 */
 	public $metadata;
 
-	public $sourceFile = NULL; // an object of type fileContainer
+	public ?FileContainer $sourceFile = NULL; // an object of type fileContainer
 	public $jobIdArray = array(); //beanstalk jobIds
 	public $regenerate = false; // regenerate derivatives
 	public $collectionId = null;
 	public $parentObjectId = null;
 	public $parentObject = null;
-	public $s3model = null;
+	public ?S3_model $s3model = null;
 	public $deleted = false;
 	public $derivatives = array(); // array of fileContainers
 	public $job; // beanstalkd current job


### PR DESCRIPTION
This is backend support for handling https://github.com/UMN-LATIS/elevator-ui/issues/546

- Update `getOriginal` in `FileManager` to take an optional action: 
  - `legacyDownload` (default) - same as existing behavior. Will attempt download, if file is archived, it will kick off a restore and show the user an html page. (This endpoint should only be used with the legacy ui), 
   - `status` - returns the status of a file: `downloadable`, `archived, `restoring`. Idempotent.
   - `restore` - kicks off restore for the file,
   - `download` - 307's to s3 download url. Will error if item is not restored.
 - Adds missing `ENVIRONMENT=local` variable to `.env.example`. This resolves`./docker/runJob.sh` failing on a fresh worktree.
 - Adds docblocks and some types (e.g. `?FileContainer`) to help IDE and make it easier to jump to the function definition.
 
