### PR TITLE
Add api support for managing auth helper groups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,10 @@ ENCRYPTION_KEY=somerandomstuffgoeshere
 # Use 'local' for normal dev work. Production servers must set this to 'production'.
 CI_ENV=local
 ENVIRONMENT=local # needed for runJob.sh
-AUTH_HELPER=AuthHelper
+# The dev/CI mock: canned remote login, group types, and entry hints.
+# NEVER on a server, it signs in anyone who asks as a superadmin.
+# Real deployments set their school's helper (UMNHelper, StOlafHelper, ...).
+AUTH_HELPER=MockAuthHelper
 
 REDIS_HOST=redis
 BEANSTALK_HOST=beanstalkd

--- a/application/controllers/AdminPermissions.php
+++ b/application/controllers/AdminPermissions.php
@@ -137,27 +137,17 @@ class AdminPermissions extends Instance_Controller {
       return abort_json(['error' => 'Invalid ID'], 400);
     }
 
-    // which resource does the URL address?
-    $route = match (true) {
-      $subresource === null && $groupId === null
-        => '/groups',
-      $subresource === null && $groupId !== null
-        => '/groups/{id}',
-      $subresource === 'members' && $subresourceId === null
-        => '/groups/{id}/members',
-      $subresource === 'members'&& $subresourceId !== null
-        => '/groups/{id}/members/{userId}',
-      $subresource === 'values' && $subresourceId === null
-        => '/groups/{id}/values',
-      $subresource === 'values' && $subresourceId !== null
-        => '/groups/{id}/values/{valueId}',
-      default
-        => null,
-    };
-
-    if ($route === null) {
-      // unknown route
-      return abort_json(['error' => 'Not Found'], 404);
+    // Build the route pattern straight from the URL shape, so the $table
+    // keys below are the single list of known routes.
+    $route = '/groups';
+    if ($groupId !== null) {
+      $route .= '/{id}';
+    }
+    if ($subresource !== null) {
+      $route .= '/' . $subresource;
+    }
+    if ($subresourceId !== null) {
+      $route .= '/{subresourceId}';
     }
 
     $table = [
@@ -175,20 +165,19 @@ class AdminPermissions extends Instance_Controller {
         'GET' => fn() => $this->listGroupMembers($groupId),
         'POST' => fn() => $this->addGroupMember($groupId),
       ],
-      '/groups/{id}/members/{userId}' => [
+      '/groups/{id}/members/{subresourceId}' => [
         'DELETE' => fn() => $this->removeGroupMember($groupId, $subresourceId),
       ],
-      '/groups/{id}/values' => [
-        'GET' => fn() => $this->listGroupValues($groupId),
-        'POST' => fn() => $this->addGroupValue($groupId),
+      '/groups/{id}/entries' => [
+        'GET' => fn() => $this->listGroupEntries($groupId),
+        'POST' => fn() => $this->addGroupEntry($groupId),
       ],
-      '/groups/{id}/values/{valueId}' => [
-        'DELETE' => fn() => $this->removeGroupValue($groupId, $subresourceId),
+      '/groups/{id}/entries/{subresourceId}' => [
+        'DELETE' => fn() => $this->removeGroupEntry($groupId, $subresourceId),
       ],
     ];
 
     if (!isset($table[$route])) {
-      // unknown route
       return abort_json(['error' => 'Not Found'], 404);
     }
 
@@ -213,7 +202,7 @@ class AdminPermissions extends Instance_Controller {
   }
 
   /**
-   * GET /adminPermissions/groups/{id} — the full group record.
+   * GET /adminPermissions/groups/{id}: the full group record.
    */
   private function showGroup(int $groupId) {
     $group = $this->doctrine->em
@@ -228,7 +217,7 @@ class AdminPermissions extends Instance_Controller {
   }
 
   /**
-   * PUT|PATCH /adminPermissions/groups/{id} — edit a group's label and type.
+   * PUT|PATCH /adminPermissions/groups/{id}: edit a group's label and type.
    *
    * Changing the type clears existing members, since they belong to the old
    * type. Editing only the label leaves them alone.
@@ -274,7 +263,7 @@ class AdminPermissions extends Instance_Controller {
   }
 
   /**
-   * DELETE /adminPermissions/groups/{id} — remove a group.
+   * DELETE /adminPermissions/groups/{id}: remove a group.
    */
   private function deleteGroup(int $groupId) {
     $group = $this->doctrine->em
@@ -293,7 +282,7 @@ class AdminPermissions extends Instance_Controller {
   }
 
   /**
-   * GET /adminPermissions/groups/{id}/members — the group's members,
+   * GET /adminPermissions/groups/{id}/members: the group's members,
    * resolved to names so the UI can show who belongs.
    */
   private function listGroupMembers(int $groupId) {
@@ -308,7 +297,7 @@ class AdminPermissions extends Instance_Controller {
   }
 
   /**
-   * POST /adminPermissions/groups/{id}/members — add one member.
+   * POST /adminPermissions/groups/{id}/members: add one member.
    *
    * Exactly one of two fields per request: `localUserId` for someone who
    * already has a local row, or `remoteUserId` (a netid/username) for someone
@@ -387,7 +376,7 @@ class AdminPermissions extends Instance_Controller {
   }
 
   /**
-   * DELETE /adminPermissions/groups/{id}/members/{userId} — drop a member.
+   * DELETE /adminPermissions/groups/{id}/members/{userId}: drop a member.
    */
   private function removeGroupMember(int $groupId, int $userId) {
     $group = $this->doctrine->em
@@ -510,7 +499,7 @@ class AdminPermissions extends Instance_Controller {
     $group->setGroupLabel($validated['label']);
 
     if ($this->ignoresGroupValues($type)) {
-      // vestigial scalar; must be 1 — Authed/Authed_remote match on it
+      // vestigial scalar, must be 1: Authed/Authed_remote match on it
       $group->setGroupValue(1);
     } else {
       $group->setGroupValue(null);
@@ -567,14 +556,10 @@ class AdminPermissions extends Instance_Controller {
    * @return Entity\User the user record matching the remote id
    */
   private function firstOrProvisionRemoteUser(string $remoteUserId): Entity\User {
-
-    /** @var AuthHelper $authHelper */
-    $authHelper = $this->user_model->getAuthHelper();
-
     // findById($id, true) will make new (unsaved) an Entity\User record with
     // the given remote id if nothing is found.
     /** @var ?Entity\User $remoteUser */
-    $remoteUser = $authHelper->findById($remoteUserId, true)[0] ?? null;
+    $remoteUser = $this->authHelper->findById($remoteUserId, true)[0] ?? null;
 
     if ($remoteUser === null) {
       throw new RemoteUserNotFoundException($remoteUserId);
@@ -600,6 +585,67 @@ class AdminPermissions extends Instance_Controller {
     $this->doctrine->em->flush();
 
     return $remoteUser;
+  }
+
+  /**
+   * GET /adminPermissions/groups/{id}/entries: a group's raw match values.
+   */
+  private function listGroupEntries(int $groupId): CI_Output {
+    $group = $this->doctrine->em
+      ->getRepository(InstanceGroup::class)
+      ->findOneBy(['id' => $groupId, 'instance' => $this->instance]);
+
+    if (!$group) {
+      return abort_json(['error' => 'Group not found'], 404);
+    }
+
+    return render_json([
+      'entries' => $group->getGroupValues()->toArray(),
+    ]);
+  }
+
+  /**
+   * POST /adminPermissions/groups/{id}/entries: add one match value.
+   */
+  private function addGroupEntry(int $groupId): CI_Output {
+    $group = $this->doctrine->em
+      ->getRepository(InstanceGroup::class)
+      ->findOneBy(['id' => $groupId, 'instance' => $this->instance]);
+
+    if (!$group) {
+      return abort_json(['error' => 'Group not found'], 404);
+    }
+
+    // User groups manage entries through /members, and global types
+    // ignore their values entirely
+    $type = $group->getGroupType();
+    if ($type === USER_TYPE || $this->ignoresGroupValues($type)) {
+      return abort_json(
+        ['error' => 'Only value-matched groups take entries'],
+        422
+      );
+    }
+
+    try {
+      $validated = V::validate($this->requestBody(), [
+        'value' => [V::required(), V::string(), V::maxLength(255)],
+      ]);
+    } catch (ValidationException $e) {
+      return abort_json(['errors' => $e->getErrors()], 422);
+    }
+
+    $entry = new Entity\GroupEntry();
+    $entry->setGroupValue($validated['value']);
+    $group->addGroupValue($entry);
+
+    $this->doctrine->em->flush();
+    $this->clearUserCache();
+
+    return render_json(['entry' => $entry], 201);
+  }
+
+  private function removeGroupEntry(int $groupId, int $entryId): CI_Output {
+    return abort_json(['error' => 'Not Implemented'], 501);
   }
 
   /**

--- a/application/controllers/AdminPermissions.php
+++ b/application/controllers/AdminPermissions.php
@@ -173,6 +173,8 @@ class AdminPermissions extends Instance_Controller {
         'POST' => fn() => $this->addGroupEntry($groupId),
       ],
       '/groups/{id}/entries/{subresourceId}' => [
+        'PUT' => fn() => $this->updateGroupEntry($groupId, $subresourceId),
+        'PATCH' => fn() => $this->updateGroupEntry($groupId, $subresourceId),
         'DELETE' => fn() => $this->removeGroupEntry($groupId, $subresourceId),
       ],
     ];
@@ -651,8 +653,100 @@ class AdminPermissions extends Instance_Controller {
     return render_json(['entry' => $entry], 201);
   }
 
+  /**
+   * PUT|PATCH /adminPermissions/groups/{id}/entries/{entryId}: edit one
+   * match value in place.
+   */
+  private function updateGroupEntry(int $groupId, int $entryId): CI_Output {
+    $group = $this->doctrine->em
+      ->getRepository(InstanceGroup::class)
+      ->findOneBy(['id' => $groupId, 'instance' => $this->instance]);
+
+    if (!$group) {
+      return abort_json(['error' => 'Group not found'], 404);
+    }
+
+    if (!$this->isAuthHelperGroupType($group->getGroupType())) {
+      return abort_json(
+        ['error' => 'Only auth-helper group types take entries'],
+        422
+      );
+    }
+
+    $entry = $this->findEntryInGroup($group, $entryId);
+    if (!$entry) {
+      return abort_json(['error' => 'Entry not found'], 404);
+    }
+
+    try {
+      $validated = V::validate($this->requestBody(), [
+        'value' => [V::required(), V::string(), V::maxLength(255)],
+      ]);
+    } catch (ValidationException $e) {
+      return abort_json(['errors' => $e->getErrors()], 422);
+    }
+
+    $entry->setGroupValue($validated['value']);
+
+    $this->doctrine->em->flush();
+    $this->clearUserCache();
+
+    return render_json(['entry' => $entry]);
+  }
+
+  /**
+   * DELETE /adminPermissions/groups/{id}/entries/{entryId}: drop one
+   * match value.
+   */
   private function removeGroupEntry(int $groupId, int $entryId): CI_Output {
-    return abort_json(['error' => 'Not Implemented'], 501);
+    $group = $this->doctrine->em
+      ->getRepository(InstanceGroup::class)
+      ->findOneBy(['id' => $groupId, 'instance' => $this->instance]);
+
+    if (!$group) {
+      return abort_json(['error' => 'Group not found'], 404);
+    }
+
+    if (!$this->isAuthHelperGroupType($group->getGroupType())) {
+      return abort_json(
+        ['error' => 'Only auth-helper group types take entries'],
+        422
+      );
+    }
+
+    $entry = $this->findEntryInGroup($group, $entryId);
+    if (!$entry) {
+      return abort_json(['error' => 'Entry not found'], 404);
+    }
+
+    $group->removeGroupValue($entry); // orphanRemoval deletes on flush
+    $this->doctrine->em->flush();
+    $this->clearUserCache();
+
+    return render_json(['removed' => $entryId]);
+  }
+
+  /**
+   * Find the entry with `$entryId` among `$group`'s own entries.
+   *
+   * Entry ids are global, so fetching one straight from the repository
+   * would let an admin address an entry belonging to another group, or
+   * another instance. Scanning the group's collection enforces ownership.
+   * The scan is cheap: the collection loads in one query and groups hold
+   * few entries.
+   *
+   * @return ?Entity\GroupEntry null when the group has no such entry
+   */
+  private function findEntryInGroup(
+    InstanceGroup $group,
+    int $entryId
+  ): ?Entity\GroupEntry {
+    foreach ($group->getGroupValues() as $candidate) {
+      if ($candidate->getId() === $entryId) {
+        return $candidate;
+      }
+    }
+    return null;
   }
 
   /**

--- a/application/controllers/AdminPermissions.php
+++ b/application/controllers/AdminPermissions.php
@@ -538,6 +538,16 @@ class AdminPermissions extends Instance_Controller {
   }
 
   /**
+   * Whether `$type` comes from the instance's AuthHelper rather than the
+   * built-in GLOBAL_GROUP_TYPES. Auth-helper groups match users on their
+   * value entries; the built-ins never do (User matches member ids, the
+   * rest match whole populations).
+   */
+  private function isAuthHelperGroupType(string $type): bool {
+    return !isset(self::GLOBAL_GROUP_TYPES[$type]);
+  }
+
+  /**
    * Whether `$type` matches a whole population instead of a values
    * list (All/Authed/Authed_remote).
    */
@@ -616,12 +626,9 @@ class AdminPermissions extends Instance_Controller {
       return abort_json(['error' => 'Group not found'], 404);
     }
 
-    // User groups manage entries through /members, and global types
-    // ignore their values entirely
-    $type = $group->getGroupType();
-    if ($type === USER_TYPE || $this->ignoresGroupValues($type)) {
+    if (!$this->isAuthHelperGroupType($group->getGroupType())) {
       return abort_json(
-        ['error' => 'Only value-matched groups take entries'],
+        ['error' => 'Only auth-helper group types take entries'],
         422
       );
     }

--- a/application/controllers/AdminPermissions.php
+++ b/application/controllers/AdminPermissions.php
@@ -120,7 +120,7 @@ class AdminPermissions extends Instance_Controller {
    * Trailing URL segments arrive as method args, so a request to
    * /adminPermissions/groups/5 calls this with $groupId = "5".
    */
-  public function groups($groupId = null, $subResource = null, $memberId = null) {
+  public function groups($groupId = null, $subresource = null, $subresourceId = null) {
     $this->abortUnlessAdmin();
 
     $method = $this->input->server('REQUEST_METHOD');
@@ -128,60 +128,74 @@ class AdminPermissions extends Instance_Controller {
     $groupId = $groupId === null
       ? null
       : filter_var($groupId, FILTER_VALIDATE_INT);
-    $memberId = $memberId === null
+    $subresourceId = $subresourceId === null
       ? null
-      : filter_var($memberId, FILTER_VALIDATE_INT);
+      : filter_var($subresourceId, FILTER_VALIDATE_INT);
 
     // a non-numeric id segment becomes false
-    if ($groupId === false || $memberId === false) {
+    if ($groupId === false || $subresourceId === false) {
       return abort_json(['error' => 'Invalid ID'], 400);
     }
 
     // which resource does the URL address?
     $route = match (true) {
-      $groupId === null => '/groups',
-      $subResource === null => '/groups/{id}',
-      $subResource !== 'members' => 'unknown',
-      $memberId === null => '/groups/{id}/members',
-      default => '/groups/{id}/members/{userId}',
+      $subresource === null && $groupId === null
+        => '/groups',
+      $subresource === null && $groupId !== null
+        => '/groups/{id}',
+      $subresource === 'members' && $subresourceId === null
+        => '/groups/{id}/members',
+      $subresource === 'members'&& $subresourceId !== null
+        => '/groups/{id}/members/{userId}',
+      $subresource === 'values' && $subresourceId === null
+        => '/groups/{id}/values',
+      $subresource === 'values' && $subresourceId !== null
+        => '/groups/{id}/values/{valueId}',
+      default
+        => null,
     };
 
-    switch ($route) {
-      case '/groups':
-        switch ($method) {
-          case 'GET':
-            return $this->listGroups();
-          case 'POST':
-            return $this->createGroup();
-        }
-        break;
-      case '/groups/{id}':
-        switch ($method) {
-          case 'GET':
-            return $this->showGroup($groupId);
-          case 'PUT':
-          case 'PATCH':
-            return $this->updateGroup($groupId);
-          case 'DELETE':
-            return $this->deleteGroup($groupId);
-        }
-        break;
-      case '/groups/{id}/members':
-        switch ($method) {
-          case 'GET':
-            return $this->listGroupMembers($groupId);
-          case 'POST':
-            return $this->addGroupMember($groupId);
-        }
-        break;
-      case '/groups/{id}/members/{userId}':
-        switch ($method) {
-          case 'DELETE':
-            return $this->removeGroupMember($groupId, $memberId);
-        }
-        break;
-      case 'unknown':
-        return abort_json(['error' => 'Not Found'], 404);
+    if ($route === null) {
+      // unknown route
+      return abort_json(['error' => 'Not Found'], 404);
+    }
+
+    $table = [
+      '/groups' => [
+        'GET' => fn() => $this->listGroups(),
+        'POST' => fn() => $this->createGroup(),
+      ],
+      '/groups/{id}' => [
+        'GET' => fn() => $this->showGroup($groupId),
+        'PUT' => fn() => $this->updateGroup($groupId),
+        'PATCH' => fn() => $this->updateGroup($groupId),
+        'DELETE' => fn() => $this->deleteGroup($groupId),
+      ],
+      '/groups/{id}/members' => [
+        'GET' => fn() => $this->listGroupMembers($groupId),
+        'POST' => fn() => $this->addGroupMember($groupId),
+      ],
+      '/groups/{id}/members/{userId}' => [
+        'DELETE' => fn() => $this->removeGroupMember($groupId, $subresourceId),
+      ],
+      '/groups/{id}/values' => [
+        'GET' => fn() => $this->listGroupValues($groupId),
+        'POST' => fn() => $this->addGroupValue($groupId),
+      ],
+      '/groups/{id}/values/{valueId}' => [
+        'DELETE' => fn() => $this->removeGroupValue($groupId, $subresourceId),
+      ],
+    ];
+
+    if (!isset($table[$route])) {
+      // unknown route
+      return abort_json(['error' => 'Not Found'], 404);
+    }
+
+    $handler = $table[$route][$method] ?? null;
+
+    if ($handler) {
+      return $handler();
     }
 
     // a known route, but the verb isn't allowed on it

--- a/application/controllers/AdminPermissions.php
+++ b/application/controllers/AdminPermissions.php
@@ -56,11 +56,43 @@ class AdminPermissions extends Instance_Controller {
         "type" => $t["name"],
         "label" => $t["label"],
         "description" => $t["helpText"] ?? "",
+        "entryHints" => $this->entryHintsForType($t["name"]),
       ],
       array_values($this->getGroupTypes())
     );
 
     return render_json(["groupTypes" => $groupTypes]);
+  }
+
+  /**
+   * Suggested entry values for one group type, from the signed-in
+   * admin's session userData.
+   *
+   * Auth helpers key hints by raw value with a human label, and PHP
+   * coerces numeric keys to ints, so each pair is recast to a
+   * {value, label} string object for the UI combobox. Local admins
+   * and helperless instances have no userData, so an empty list is
+   * normal, not an error.
+   */
+  private function entryHintsForType(string $type): array {
+    // Global types never take entries. Guard by type category rather
+    // than trusting that no auth helper ever keys its userData by a
+    // global type name, since helpers pick their keys independently.
+    if (!$this->isAuthHelperGroupType($type)) {
+      return [];
+    }
+
+    $hints = $this->user_model->userData[$type]["hints"] ?? [];
+
+    $entryHints = [];
+    foreach ($hints as $rawValue => $label) {
+      $entryHints[] = [
+        "value" => (string) $rawValue,
+        "label" => (string) $label,
+      ];
+    }
+
+    return $entryHints;
   }
 
   public function permissionLevels() {

--- a/application/controllers/AdminPermissions.php
+++ b/application/controllers/AdminPermissions.php
@@ -643,6 +643,13 @@ class AdminPermissions extends Instance_Controller {
       return abort_json(['error' => 'Group not found'], 404);
     }
 
+    if (!$this->isAuthHelperGroupType($group->getGroupType())) {
+      return abort_json(
+        ['error' => 'Only auth-helper group types take entries'],
+        422
+      );
+    }
+
     return render_json([
       'entries' => $group->getGroupValues()->toArray(),
     ]);

--- a/application/libraries/MockAuthHelper.php
+++ b/application/libraries/MockAuthHelper.php
@@ -1,0 +1,242 @@
+<?php
+/**
+ * Canned-data auth helper for local dev and CI, modeled on UMNHelper.
+ *
+ * Fakes the whole remote-auth surface with fixtures: remoteLogin() plants
+ * the session attributes Shibboleth would have left, so visiting
+ * /loginManager/remoteLogin signs you in as a canned Remote user with no
+ * credentials, and populateUserData() returns fixed values and hints for
+ * the UMN group types. Select it with AUTH_HELPER=MockAuthHelper.
+ *
+ * SECURITY: this helper signs in anyone who asks, as a superadmin. The
+ * constructor refuses to run when ENVIRONMENT is production, but do not
+ * point any shared or internet-facing instance at it.
+ */
+
+require_once("AuthHelper.php");
+
+class MockAuthHelper extends AuthHelper
+{
+  public $authTypes = [
+    UNIT_TYPE => [
+      "name" => UNIT_TYPE,
+      "label" => UNIT_TYPE
+    ],
+    JOB_TYPE => ["name" => JOB_TYPE, "label" => "Job Code"],
+    COURSE_TYPE => ["name" => COURSE_TYPE, "label" => COURSE_TYPE],
+    DEPT_COURSE_TYPE => [
+      "name" => DEPT_COURSE_TYPE,
+      "label" => DEPT_COURSE_TYPE,
+      "helpText" => "Use % for wildcard, like DEPT.NUMBER% to include all sections."
+    ],
+    STATUS_TYPE => ["name" => STATUS_TYPE, "label" => "Student Status"],
+    EMPLOYEE_TYPE => ["name" => EMPLOYEE_TYPE, "label" => "Employee Type"]
+  ];
+
+  // The one identity remoteLogin() signs in.
+  const MOCK_REMOTE_USER = [
+    "username" => "mockinstructor",
+    "displayName" => "Mock Instructor",
+    "email" => "mockinstructor@example.edu",
+  ];
+
+  // Stand-in for the external people directory (bandaid at UMN). These
+  // back findById/autocomplete, so member-add by remote id works.
+  const MOCK_DIRECTORY = [
+    [
+      "username" => "mockstudent",
+      "displayName" => "Mock Student",
+      "email" => "mockstudent@example.edu",
+    ],
+    [
+      "username" => "mockstaff",
+      "displayName" => "Mock Staff",
+      "email" => "mockstaff@example.edu",
+    ],
+    [
+      "username" => "mockprofessor",
+      "displayName" => "Mock Professor",
+      "email" => "mockprofessor@example.edu",
+    ],
+  ];
+
+  // The guard is an allowlist so an unexpected or missing CI_ENV fails
+  // closed rather than open (index.php defaults ENVIRONMENT to
+  // development when CI_ENV is unset).
+  const ALLOWED_ENVIRONMENTS = ['development', 'local', 'testing'];
+
+  public function __construct()
+  {
+    if (!in_array(ENVIRONMENT, self::ALLOWED_ENVIRONMENTS, true)) {
+      show_error('MockAuthHelper grants credential-less login and only runs in development, local, or testing environments. Set AUTH_HELPER to your real auth helper.', 500);
+    }
+    parent::__construct();
+  }
+
+  /**
+   * Fake the Shibboleth handshake: plant the session attributes the rest
+   * of LoginManager::remoteLogin reads, then return false so it continues
+   * into user lookup and provisioning instead of redirecting.
+   */
+  public function remoteLogin($redirectURL, $noForcedAuth = false): bool
+  {
+    $this->CI->session->set_userdata([
+      'userAuthField' => self::MOCK_REMOTE_USER['username'],
+      'userAttributesCache' => [
+        'uniqueIdentifier' => self::MOCK_REMOTE_USER['username'],
+        'isGuest' => 'N',
+      ],
+    ]);
+    return false;
+  }
+
+  public function getUserIdFromRemote($map = null): ?string
+  {
+    if ($map) {
+      return $map["uniqueIdentifier"];
+    }
+    return $this->CI->session->userdata('userAuthField');
+  }
+
+  /**
+   * Provision the canned Remote user on first mock login.
+   *
+   * Superadmin so the mock user can exercise admin screens without
+   * seeded permission rows. Safe only because the production guard
+   * keeps this class out of real deployments.
+   */
+  public function createUserFromRemote($userOverride = null, $map = null)
+  {
+    $user = new Entity\User;
+    $user->setUsername(self::MOCK_REMOTE_USER['username']);
+    $user->setDisplayName(self::MOCK_REMOTE_USER['displayName']);
+    $user->setEmail(self::MOCK_REMOTE_USER['email']);
+    $user->setUserType("Remote");
+    $user->setHasExpiry(false);
+    $user->setCreatedAt(new \DateTime("now"));
+    $user->setInstance($this->CI->instance);
+    $user->setIsSuperAdmin(true);
+    $user->setFastUpload(false);
+    $this->CI->doctrine->em->persist($user);
+    $this->CI->doctrine->em->flush();
+    return $user;
+  }
+
+  /**
+   * Canned values and hints for every type, in UMNHelper's exact shape.
+   *
+   * Class Number hints keep numeric keys and JobCode keeps empty hints
+   * on purpose, both are real UMN quirks downstream code must handle.
+   * Cached per user for 4 hours in the Redis userCache, so edits here
+   * need a cache clear (any group mutation, or a docker restart).
+   */
+  public function populateUserData($user): array
+  {
+    return [
+      COURSE_TYPE => [
+        "values" => ["12345", "23456"],
+        "hints" => [
+          12345 => "ART.1234.001",
+          23456 => "CSCI.2021.010",
+        ],
+      ],
+      DEPT_COURSE_TYPE => [
+        "values" => ["ART.1234.001", "CSCI.2021.010"],
+        "hints" => [
+          "ART.1234.001" => "Drawing I",
+          "CSCI.2021.010" => "Machine Architecture",
+        ],
+      ],
+      JOB_TYPE => ["values" => ["9403"], "hints" => []],
+      UNIT_TYPE => [
+        "values" => ["CLA-ART", "CSE-CSCI"],
+        "hints" => ["CLA-ART" => "CLA-ART", "CSE-CSCI" => "CSE-CSCI"],
+      ],
+      STATUS_TYPE => [
+        "values" => ["GRAD"],
+        "hints" => ["UGRD" => "Undergraduate", "GRAD" => "Graduate"],
+      ],
+      EMPLOYEE_TYPE => [
+        "values" => ["Faculty"],
+        "hints" => [
+          "Faculty" => "Faculty",
+          "Student" => "Student",
+          "Staff" => "Staff",
+        ],
+      ],
+    ];
+  }
+
+  public function getGroupMapping($userData): array
+  {
+    $outputArray = [];
+    if (!$userData || !is_array($userData)) {
+      return $outputArray;
+    }
+    foreach ($userData as $key => $value) {
+      $outputArray[$key] = $value["values"];
+    }
+    return $outputArray;
+  }
+
+  public function findById($key, $createMissing = false): array
+  {
+    return $this->findInMockDirectory($key);
+  }
+
+  public function findUserByUsername($key, $createMissing = false): array
+  {
+    return $this->findInMockDirectory($key);
+  }
+
+  public function findUserByName($key, $createMissing = false): array
+  {
+    return $this->findInMockDirectory($key);
+  }
+
+  public function autocompleteUsername($partialUsername): array
+  {
+    $outputArray = parent::autocompleteUsername($partialUsername);
+
+    foreach ($this->findInMockDirectory($partialUsername) as $user) {
+      $isDuplicate = false;
+      foreach ($outputArray as $entry) {
+        if ($entry["username"] == $user->getUsername()) {
+          $isDuplicate = true;
+        }
+      }
+      if (!$isDuplicate) {
+        $outputArray[] = [
+          "name" => $user->getDisplayName(),
+          "email" => $user->getEmail(),
+          "completionId" => $user->getId(),
+          "username" => $user->getUsername(),
+        ];
+      }
+    }
+
+    return $outputArray;
+  }
+
+  /**
+   * Case-insensitive substring match on username or display name.
+   *
+   * @return Entity\User[] unsaved records, the same convention as
+   * UMNHelper::findUser, callers persist them on first use
+   */
+  private function findInMockDirectory(string $key): array
+  {
+    $matches = [];
+    foreach (self::MOCK_DIRECTORY as $person) {
+      $haystack = strtolower($person["username"] . " " . $person["displayName"]);
+      if (str_contains($haystack, strtolower($key))) {
+        $user = new Entity\User;
+        $user->setUsername($person["username"]);
+        $user->setDisplayName($person["displayName"]);
+        $user->setEmail($person["email"]);
+        $matches[] = $user;
+      }
+    }
+    return $matches;
+  }
+}

--- a/application/libraries/MockAuthHelper.php
+++ b/application/libraries/MockAuthHelper.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Canned-data auth helper for local dev and CI, modeled on UMNHelper.
  *
@@ -8,15 +9,14 @@
  * credentials, and populateUserData() returns fixed values and hints for
  * the UMN group types. Select it with AUTH_HELPER=MockAuthHelper.
  *
- * SECURITY: this helper signs in anyone who asks, as a superadmin. The
- * constructor refuses to run when ENVIRONMENT is production, but do not
- * point any shared or internet-facing instance at it.
+ * SECURITY: This should NEVER be run in production since it skips legit auth.
+ * As a safeguard, the constructor refuses to run when ENVIRONMENT is
+ * production (if somehow the ENV was set).
  */
 
 require_once("AuthHelper.php");
 
-class MockAuthHelper extends AuthHelper
-{
+class MockAuthHelper extends AuthHelper {
   public $authTypes = [
     UNIT_TYPE => [
       "name" => UNIT_TYPE,
@@ -65,8 +65,7 @@ class MockAuthHelper extends AuthHelper
   // development when CI_ENV is unset).
   const ALLOWED_ENVIRONMENTS = ['development', 'local', 'testing'];
 
-  public function __construct()
-  {
+  public function __construct() {
     if (!in_array(ENVIRONMENT, self::ALLOWED_ENVIRONMENTS, true)) {
       show_error('MockAuthHelper grants credential-less login and only runs in development, local, or testing environments. Set AUTH_HELPER to your real auth helper.', 500);
     }
@@ -78,8 +77,7 @@ class MockAuthHelper extends AuthHelper
    * of LoginManager::remoteLogin reads, then return false so it continues
    * into user lookup and provisioning instead of redirecting.
    */
-  public function remoteLogin($redirectURL, $noForcedAuth = false): bool
-  {
+  public function remoteLogin($redirectURL, $noForcedAuth = false): bool {
     $this->CI->session->set_userdata([
       'userAuthField' => self::MOCK_REMOTE_USER['username'],
       'userAttributesCache' => [
@@ -90,8 +88,7 @@ class MockAuthHelper extends AuthHelper
     return false;
   }
 
-  public function getUserIdFromRemote($map = null): ?string
-  {
+  public function getUserIdFromRemote($map = null): ?string {
     if ($map) {
       return $map["uniqueIdentifier"];
     }
@@ -105,8 +102,7 @@ class MockAuthHelper extends AuthHelper
    * seeded permission rows. Safe only because the production guard
    * keeps this class out of real deployments.
    */
-  public function createUserFromRemote($userOverride = null, $map = null)
-  {
+  public function createUserFromRemote($userOverride = null, $map = null) {
     $user = new Entity\User;
     $user->setUsername(self::MOCK_REMOTE_USER['username']);
     $user->setDisplayName(self::MOCK_REMOTE_USER['displayName']);
@@ -124,14 +120,8 @@ class MockAuthHelper extends AuthHelper
 
   /**
    * Canned values and hints for every type, in UMNHelper's exact shape.
-   *
-   * Class Number hints keep numeric keys and JobCode keeps empty hints
-   * on purpose, both are real UMN quirks downstream code must handle.
-   * Cached per user for 4 hours in the Redis userCache, so edits here
-   * need a cache clear (any group mutation, or a docker restart).
    */
-  public function populateUserData($user): array
-  {
+  public function populateUserData($user): array {
     return [
       COURSE_TYPE => [
         "values" => ["12345", "23456"],
@@ -171,8 +161,7 @@ class MockAuthHelper extends AuthHelper
     ];
   }
 
-  public function getGroupMapping($userData): array
-  {
+  public function getGroupMapping($userData): array {
     $outputArray = [];
     if (!$userData || !is_array($userData)) {
       return $outputArray;
@@ -183,23 +172,19 @@ class MockAuthHelper extends AuthHelper
     return $outputArray;
   }
 
-  public function findById($key, $createMissing = false): array
-  {
+  public function findById($key, $createMissing = false): array {
     return $this->findInMockDirectory($key);
   }
 
-  public function findUserByUsername($key, $createMissing = false): array
-  {
+  public function findUserByUsername($key, $createMissing = false): array {
     return $this->findInMockDirectory($key);
   }
 
-  public function findUserByName($key, $createMissing = false): array
-  {
+  public function findUserByName($key, $createMissing = false): array {
     return $this->findInMockDirectory($key);
   }
 
-  public function autocompleteUsername($partialUsername): array
-  {
+  public function autocompleteUsername($partialUsername): array {
     $outputArray = parent::autocompleteUsername($partialUsername);
 
     foreach ($this->findInMockDirectory($partialUsername) as $user) {
@@ -228,8 +213,7 @@ class MockAuthHelper extends AuthHelper
    * @return Entity\User[] unsaved records, the same convention as
    * UMNHelper::findUser, callers persist them on first use
    */
-  private function findInMockDirectory(string $key): array
-  {
+  private function findInMockDirectory(string $key): array {
     $matches = [];
     foreach (self::MOCK_DIRECTORY as $person) {
       $haystack = strtolower($person["username"] . " " . $person["displayName"]);

--- a/application/libraries/MockAuthHelper.php
+++ b/application/libraries/MockAuthHelper.php
@@ -147,7 +147,11 @@ class MockAuthHelper extends AuthHelper
           "CSCI.2021.010" => "Machine Architecture",
         ],
       ],
-      JOB_TYPE => ["values" => ["9403"], "hints" => []],
+      JOB_TYPE => ["values" => ["9403"], "hints" => [
+        '9403' => "Instructor",
+        '9404' => "TA",
+        '9405' => "Grader",
+      ]],
       UNIT_TYPE => [
         "values" => ["CLA-ART", "CSE-CSCI"],
         "hints" => ["CLA-ART" => "CLA-ART", "CSE-CSCI" => "CSE-CSCI"],

--- a/application/libraries/SimpleValidator.php
+++ b/application/libraries/SimpleValidator.php
@@ -6,11 +6,11 @@ class SimpleValidator
   /**
    * Validates $data against $schema (array of field => closure[])
    * Returns filtered data or throws ValidationException
-   * 
+   *
    * @example
    * ```php
    * use SimpleValidator as V;
-   * 
+   *
    * $data = [
    *  'name' => 'John Doe',
    *  'age' => 30,
@@ -19,7 +19,7 @@ class SimpleValidator
    *  'name' => [V::required(), V::minLength(3)],
    *  'age' => [V::required(), V::integer(), V::min(18)],
    * ];
-   * 
+   *
    * try {
    *  $validatedData = V::validate($data, $schema);
    * } catch (ValidationException $e) {
@@ -49,7 +49,7 @@ class SimpleValidator
     return array_intersect_key($data, $schema);
   }
 
-  // —–––– Validators —––––
+  // ----- Validators
 
   public static function required(): \Closure
   {

--- a/application/libraries/SimpleValidator.php
+++ b/application/libraries/SimpleValidator.php
@@ -66,6 +66,11 @@ class SimpleValidator
     return fn($v) => !isset($v) || is_array($v) ? true : 'Must be an array';
   }
 
+  public static function string(): \Closure
+  {
+    return fn($v) => !isset($v) || is_string($v) ? true : 'Must be a string';
+  }
+
   public static function min(int $min): \Closure
   {
     return fn($v) => !isset($v) || (is_numeric($v) && $v >= $min)

--- a/application/models/Entity/InstanceGroup.php
+++ b/application/models/Entity/InstanceGroup.php
@@ -326,7 +326,8 @@ class InstanceGroup implements \JsonSerializable
             'id'         => $this->id,
             'type'       => $this->group_type,
             'label'      => $this->group_label,
-            'entries_count' => count($this->group_values->toArray()),
+            // n+1 query, but prob fine at our scale
+            'entries_count' => $this->group_values->count(),
         ];
     }
 }

--- a/application/models/Entity/InstanceGroup.php
+++ b/application/models/Entity/InstanceGroup.php
@@ -325,12 +325,7 @@ class InstanceGroup implements \JsonSerializable
         return [
             'id'         => $this->id,
             'type'       => $this->group_type,
-            // the `group_value` col is vestigial for
-            // auth types that don't have a value-based
-            // match like `Authed` or `Authed_remote`
-            // 'ignoresGroupValues'      => isset($this->group_value),
             'label'      => $this->group_label,
-            'expiration' => $this->expiration?->format(\DateTime::ATOM),
             'values'     => array_values($this->group_values->toArray()),
         ];
     }

--- a/application/models/Entity/InstanceGroup.php
+++ b/application/models/Entity/InstanceGroup.php
@@ -326,7 +326,7 @@ class InstanceGroup implements \JsonSerializable
             'id'         => $this->id,
             'type'       => $this->group_type,
             'label'      => $this->group_label,
-            'values'     => array_values($this->group_values->toArray()),
+            'entries_count' => count($this->group_values->toArray()),
         ];
     }
 }

--- a/tests/api/groups.spec.ts
+++ b/tests/api/groups.spec.ts
@@ -60,9 +60,9 @@ type GroupEntry = {
 };
 
 // Entries only exist on auth-helper group types, and the instance's helper
-// may define none (the base AuthHelper is empty, and CI runs with it).
-// Discover a type at runtime so entry tests can skip on a bare instance
-// instead of failing.
+// may define none (the base AuthHelper is empty). CI runs MockAuthHelper,
+// which defines the UMN types. Discover a type at runtime so entry tests
+// can skip on a bare instance instead of failing.
 async function findAuthHelperGroupType(page: Page): Promise<string | null> {
   const res = await page.request.get(
     `${baseURL()}/adminPermissions/groupTypes`,
@@ -140,11 +140,10 @@ test.describe("adminPermissions", () => {
       for (const groupType of groupTypes) {
         expect(Array.isArray(groupType.entryHints)).toBe(true);
 
-        // Hints come from the admin's own session data, so they are
-        // usually empty here (CI logs in a local admin against the bare
-        // AuthHelper). When present, pin the {value, label} string shape
-        // the combobox consumes. PHP coerces numeric hint keys to ints,
-        // so value being a string is the assertion that matters.
+        // Hints come from the admin's own session data, and this suite
+        // logs in a local admin, who has none. The populated case lives
+        // in mockAuth.spec.ts. When present, pin the {value, label}
+        // string shape the combobox consumes.
         for (const hint of groupType.entryHints) {
           expect(typeof hint.value).toBe("string");
           expect(typeof hint.label).toBe("string");

--- a/tests/api/groups.spec.ts
+++ b/tests/api/groups.spec.ts
@@ -12,7 +12,7 @@ type Group = {
   id: number;
   type: string;
   label: string;
-  values: unknown[];
+  entries_count: number;
 };
 
 // Create a group through the public endpoint and return its parsed record,
@@ -52,6 +52,30 @@ async function findUserByUsername(
   const match = matches.find((m) => m.username === username);
   expect(match, `no autocomplete match for "${username}"`).toBeTruthy();
   return match as UserMatch;
+}
+
+type GroupEntry = {
+  id: number;
+  value: string;
+};
+
+// Entries only exist on auth-helper group types, and the instance's helper
+// may define none (the base AuthHelper is empty, and CI runs with it).
+// Discover a type at runtime so entry tests can skip on a bare instance
+// instead of failing.
+async function findAuthHelperGroupType(page: Page): Promise<string | null> {
+  const res = await page.request.get(
+    `${baseURL()}/adminPermissions/groupTypes`,
+    { headers: { Accept: "application/json" } },
+  );
+  expect(res.status()).toBe(200);
+  const { groupTypes } = (await res.json()) as {
+    groupTypes: { type: string }[];
+  };
+  const globalTypes = ["All", "Authed", "Authed_remote", "User"];
+  const isAuthHelperType = (g: { type: string }) =>
+    !globalTypes.includes(g.type);
+  return groupTypes.find(isAuthHelperType)?.type ?? null;
 }
 
 test.describe("adminPermissions", () => {
@@ -166,7 +190,7 @@ test.describe("adminPermissions", () => {
       // The group_value scalar is set to 1 server-side so Authed/Remote
       // matching keeps working, but it's a DB-internal detail and is
       // deliberately not part of the JSON contract.
-      expect(group.values).toEqual([]);
+      expect(group.entries_count).toBe(0);
     });
 
     test("a created group appears in the list", async ({ page }) => {
@@ -349,7 +373,7 @@ test.describe("adminPermissions", () => {
 
       const { group: updated } = await res.json();
       expect(updated.type).toBe("Authed");
-      expect(updated.values).toEqual([]);
+      expect(updated.entries_count).toBe(0);
     });
 
     test("returns 404 for a missing group", async ({ page }) => {
@@ -511,6 +535,106 @@ test.describe("adminPermissions", () => {
     test("listing members of a missing group returns 404", async ({ page }) => {
       const res = await page.request.get(
         `${baseURL()}/adminPermissions/groups/99999999/members`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(res.status()).toBe(404);
+    });
+  });
+
+  test.describe("group entries", () => {
+    test.beforeAll(() => {
+      refreshDatabase();
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await loginAdmin(page);
+    });
+
+    test.afterEach(() => {
+      refreshDatabase();
+    });
+
+    test("adds, lists, updates, and removes an entry", async ({ page }) => {
+      const type = await findAuthHelperGroupType(page);
+      if (type === null) {
+        test.skip(true, "the instance's auth helper defines no group types");
+        return;
+      }
+
+      const group = await createGroup(page, { type, label: "Attributes" });
+
+      const add = await page.request.post(
+        `${baseURL()}/adminPermissions/groups/${group.id}/entries`,
+        { form: { value: "CSCI.1001" } },
+      );
+      expect(add.status()).toBe(201);
+      const { entry } = (await add.json()) as { entry: GroupEntry };
+      expect(entry.value).toBe("CSCI.1001");
+
+      const list = await page.request.get(
+        `${baseURL()}/adminPermissions/groups/${group.id}/entries`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(list.status()).toBe(200);
+      const { entries } = (await list.json()) as { entries: GroupEntry[] };
+      expect(entries.some((e) => e.id === entry.id)).toBe(true);
+
+      const update = await page.request.put(
+        `${baseURL()}/adminPermissions/groups/${group.id}/entries/${entry.id}`,
+        { form: { value: "CSCI.2001" } },
+      );
+      expect(update.status()).toBe(200);
+      const updated = (await update.json()) as { entry: GroupEntry };
+      expect(updated.entry.value).toBe("CSCI.2001");
+
+      const remove = await page.request.delete(
+        `${baseURL()}/adminPermissions/groups/${group.id}/entries/${entry.id}`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(remove.status()).toBe(200);
+      expect((await remove.json()).removed).toBe(entry.id);
+    });
+
+    test("only auth-helper group types take entries", async ({ page }) => {
+      const group = await createGroup(page, {
+        type: "User",
+        label: "NoEntries",
+      });
+
+      const res = await page.request.post(
+        `${baseURL()}/adminPermissions/groups/${group.id}/entries`,
+        { form: { value: "anything" } },
+      );
+      expect(res.status()).toBe(422);
+    });
+
+    test("updating or removing a missing entry returns 404", async ({
+      page,
+    }) => {
+      const type = await findAuthHelperGroupType(page);
+      if (type === null) {
+        test.skip(true, "the instance's auth helper defines no group types");
+        return;
+      }
+
+      const group = await createGroup(page, { type, label: "NoSuchEntry" });
+
+      const update = await page.request.put(
+        `${baseURL()}/adminPermissions/groups/${group.id}/entries/99999999`,
+        { form: { value: "anything" } },
+      );
+      expect(update.status()).toBe(404);
+
+      const remove = await page.request.delete(
+        `${baseURL()}/adminPermissions/groups/${group.id}/entries/99999999`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(remove.status()).toBe(404);
+    });
+
+    test("listing entries of a missing group returns 404", async ({ page }) => {
+      const res = await page.request.get(
+        `${baseURL()}/adminPermissions/groups/99999999/entries`,
         { headers: { Accept: "application/json" } },
       );
       expect(res.status()).toBe(404);

--- a/tests/api/groups.spec.ts
+++ b/tests/api/groups.spec.ts
@@ -112,12 +112,51 @@ test.describe("adminPermissions", () => {
 
       const { groupTypes } = await res.json();
       expect(Array.isArray(groupTypes)).toBe(true);
-      // Each entry is { type, label, description }; check the type strings.
+      // Each entry is { type, label, description, entryHints }; check
+      // the type strings here, entryHints has its own test below.
       const types = groupTypes.map((g: { type: string }) => g.type);
       // The global types are always present regardless of auth helper.
       expect(types).toEqual(
         expect.arrayContaining(["All", "Authed", "Authed_remote", "User"]),
       );
+    });
+
+    test("GET /groupTypes includes entryHints on every type", async ({
+      page,
+    }) => {
+      const res = await page.request.get(
+        `${baseURL()}/adminPermissions/groupTypes`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(res.status()).toBe(200);
+
+      const { groupTypes } = (await res.json()) as {
+        groupTypes: {
+          type: string;
+          entryHints: { value: string; label: string }[];
+        }[];
+      };
+
+      for (const groupType of groupTypes) {
+        expect(Array.isArray(groupType.entryHints)).toBe(true);
+
+        // Hints come from the admin's own session data, so they are
+        // usually empty here (CI logs in a local admin against the bare
+        // AuthHelper). When present, pin the {value, label} string shape
+        // the combobox consumes. PHP coerces numeric hint keys to ints,
+        // so value being a string is the assertion that matters.
+        for (const hint of groupType.entryHints) {
+          expect(typeof hint.value).toBe("string");
+          expect(typeof hint.label).toBe("string");
+        }
+      }
+
+      // Global types never take entries, so they never suggest any.
+      const globalTypes = ["All", "Authed", "Authed_remote", "User"];
+      const globalEntryHints = groupTypes
+        .filter((g) => globalTypes.includes(g.type))
+        .flatMap((g) => g.entryHints);
+      expect(globalEntryHints).toEqual([]);
     });
 
     test("GET /permissionLevels returns levels sorted ascending", async ({

--- a/tests/api/groups.spec.ts
+++ b/tests/api/groups.spec.ts
@@ -644,6 +644,14 @@ test.describe("adminPermissions", () => {
         { form: { value: "anything" } },
       );
       expect(res.status()).toBe(422);
+
+      // The read side too: User groups store membership in the same
+      // group_values rows, so listing must not serve member ids as entries.
+      const list = await page.request.get(
+        `${baseURL()}/adminPermissions/groups/${group.id}/entries`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(list.status()).toBe(422);
     });
 
     test("updating or removing a missing entry returns 404", async ({

--- a/tests/api/mockAuth.spec.ts
+++ b/tests/api/mockAuth.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect, type Page } from "@playwright/test";
+import { baseURL } from "../helpers";
+
+// MockAuthHelper (AUTH_HELPER=MockAuthHelper) fakes the remote-auth surface
+// with canned data: /loginManager/remoteLogin signs in a superadmin Remote
+// user with no credentials, populateUserData returns fixed hints, and a
+// canned directory backs findById/autocomplete. These tests cover the flows
+// no local login can reach (populated entryHints, remote member-add) and
+// skip when the instance runs a different helper, e.g. a UMN-configured
+// dev machine.
+
+type EntryHint = { value: string; label: string };
+
+type GroupType = {
+  type: string;
+  label: string;
+  description: string;
+  entryHints: EntryHint[];
+};
+
+// Sign in through the mock remote flow. Returns false when the instance is
+// not mock-configured: a real helper redirects to Shibboleth, nothing
+// authenticates, and the admin probe comes back 401.
+async function loginMockRemote(page: Page): Promise<boolean> {
+  // A real helper 302s toward its identity provider here. Swallow any
+  // network error from an unreachable IdP so the probe below can skip
+  // instead of failing.
+  await page.request
+    .get(`${baseURL()}/loginManager/remoteLogin`)
+    .catch(() => undefined);
+  const probe = await page.request.get(
+    `${baseURL()}/adminPermissions/groupTypes`,
+    { headers: { Accept: "application/json" } },
+  );
+  return probe.status() === 200;
+}
+
+async function fetchGroupTypes(page: Page): Promise<GroupType[]> {
+  const res = await page.request.get(
+    `${baseURL()}/adminPermissions/groupTypes`,
+    { headers: { Accept: "application/json" } },
+  );
+  expect(res.status()).toBe(200);
+  const { groupTypes } = (await res.json()) as { groupTypes: GroupType[] };
+  return groupTypes;
+}
+
+test.describe("mock remote auth", () => {
+  test.beforeEach(async ({ page }) => {
+    const isMockConfigured = await loginMockRemote(page);
+    test.skip(!isMockConfigured, "instance is not running MockAuthHelper");
+  });
+
+  // Provisioned user rows (mockinstructor, mockstudent) persist across
+  // runs, the flows under test tolerate existing rows. Groups created
+  // here are deleted in the test that makes them.
+
+  test("remoteLogin signs in with no credentials and exposes the mock types", async ({
+    page,
+  }) => {
+    // beforeEach already logged in; a 200 admin read proves the session.
+    const groupTypes = await fetchGroupTypes(page);
+    const types = groupTypes.map((groupType) => groupType.type);
+    expect(types).toEqual(
+      expect.arrayContaining([
+        "Unit",
+        "JobCode",
+        "Class Number",
+        "Dept/Course Number",
+        "StudentStatus",
+        "EmployeeType",
+      ]),
+    );
+  });
+
+  test("entryHints are populated for the mock remote user", async ({
+    page,
+  }) => {
+    const groupTypes = await fetchGroupTypes(page);
+    const byType = new Map(groupTypes.map((g) => [g.type, g]));
+
+    // Class Number hints are keyed by numeric class numbers in the mock
+    // (as at UMN), so string values here pin the int-coercion cast in
+    // entryHintsForType end to end.
+    const classNumber = byType.get("Class Number");
+    expect(classNumber?.entryHints).toContainEqual({
+      value: "12345",
+      label: "ART.1234.001",
+    });
+
+    // JobCode has values but no hints, the empty case must survive a
+    // populated session too.
+    expect(byType.get("JobCode")?.entryHints).toEqual([]);
+
+    // Global types stay empty even when the session has userData.
+    expect(byType.get("User")?.entryHints).toEqual([]);
+  });
+
+  test("adds a group member by remote id from the mock directory", async ({
+    page,
+  }) => {
+    const createRes = await page.request.post(
+      `${baseURL()}/adminPermissions/groups`,
+      { form: { type: "User", label: "Mock directory members" } },
+    );
+    expect(createRes.status()).toBe(201);
+    const { group } = (await createRes.json()) as { group: { id: number } };
+
+    // mockstudent has no local row yet, so this exercises provisioning
+    // through MockAuthHelper::findById.
+    const addRes = await page.request.post(
+      `${baseURL()}/adminPermissions/groups/${group.id}/members`,
+      { form: { remoteUserId: "mockstudent" } },
+    );
+    expect(addRes.status()).toBe(201);
+    const { member } = (await addRes.json()) as {
+      member: { username: string; name: string };
+    };
+    expect(member.username).toBe("mockstudent");
+    expect(member.name).toBe("Mock Student");
+
+    const listRes = await page.request.get(
+      `${baseURL()}/adminPermissions/groups/${group.id}/members`,
+      { headers: { Accept: "application/json" } },
+    );
+    expect(listRes.status()).toBe(200);
+    const { members } = (await listRes.json()) as {
+      members: { username: string }[];
+    };
+    expect(members.map((m) => m.username)).toContain("mockstudent");
+
+    // The reset script doesn't cover groups, so clean up our own.
+    const deleteRes = await page.request.delete(
+      `${baseURL()}/adminPermissions/groups/${group.id}`,
+    );
+    expect(deleteRes.status()).toBe(200);
+  });
+});

--- a/tests/api/mockAuth.spec.ts
+++ b/tests/api/mockAuth.spec.ts
@@ -88,9 +88,11 @@ test.describe("mock remote auth", () => {
       label: "ART.1234.001",
     });
 
-    // JobCode has values but no hints, the empty case must survive a
-    // populated session too.
-    expect(byType.get("JobCode")?.entryHints).toEqual([]);
+    // JobCode hints are keyed by string codes in the mock.
+    expect(byType.get("JobCode")?.entryHints).toContainEqual({
+      value: "9403",
+      label: "Instructor",
+    });
 
     // Global types stay empty even when the session has userData.
     expect(byType.get("User")?.entryHints).toEqual([]);


### PR DESCRIPTION
- Part of UMN-LATIS/elevator-ui#538, slice 2 (auth-helper groups), API side
- Adds `/adminPermissions/groups/{id}/entries` CRUD so the new UI can manage an auth-helper group's match values (wildcards like `ART-1234-%-FA26` allowed, they are LIKE patterns)
- Adds `entryHints` property to `GET /adminPermissions/groupTypes` which contains suggested values from the admin's own session data to feed the ui autocomplete combobox.
- **Adds `MockAuthHelper`**, a canned-data helper for dev and CI: credential-less remote login, UMN group types, populated hints. It's guarded to prevent accidental runs in production (if the env was somehow set to this). This is mostly a copy of UMNHelper, but it's a non-trivial amount of code. It was helpful for local testing of entry value logic, but could removed if you want to keep this PR lighter or there's some interaction I didn't think about.
- Refactors the `groups()` dispatcher to a route table when adding new CRUD routes for better readability.
- Changes `groups` endpoint to return a count of the entries/members rather than every member/entry. (We only need the count until the accordion opens.)