### PR TITLE
Drawer permission grants API

### DIFF
--- a/application/controllers/DrawerPermissions.php
+++ b/application/controllers/DrawerPermissions.php
@@ -221,10 +221,7 @@ class DrawerPermissions extends Instance_Controller {
       return abort_json(['error' => 'Group not found'], 422);
     }
 
-    $level = $this->em->find(Permission::class, (int) $validated['permissionLevelId']);
-    if (!$level) {
-      return abort_json(['error' => 'Permission level not found'], 422);
-    }
+    $level = $this->findDrawerGrantLevelOrAbort((int) $validated['permissionLevelId']);
 
     $existing = $this->findDrawerPermissionForGroup($drawer, $group);
     if ($existing) {
@@ -272,10 +269,7 @@ class DrawerPermissions extends Instance_Controller {
       return abort_json(['errors' => $e->getErrors()], 422);
     }
 
-    $level = $this->em->find(Permission::class, (int) $validated['permissionLevelId']);
-    if (!$level) {
-      return abort_json(['error' => 'Permission level not found'], 422);
-    }
+    $level = $this->findDrawerGrantLevelOrAbort((int) $validated['permissionLevelId']);
 
     // re-level only, the M2M link already exists and stays put
     $grant->setPermission($level);
@@ -834,6 +828,25 @@ class DrawerPermissions extends Instance_Controller {
     }
 
     return $drawer;
+  }
+
+  /**
+   * The permission level with `$levelId`, aborting 422 when it does not
+   * exist or sits above PERM_ORIGINALS. Drawer grants cap at originals,
+   * matching the ceiling the legacy permissions editor enforced, so a
+   * drawer manager cannot raise anyone (themselves included) to admin.
+   */
+  private function findDrawerGrantLevelOrAbort(int $levelId): Permission {
+    $level = $this->em->find(Permission::class, $levelId);
+    if (!$level) {
+      abort_json(['error' => 'Permission level not found'], 422);
+    }
+
+    if ((int) $level->getLevel() > PERM_ORIGINALS) {
+      abort_json(['error' => 'Drawer grants cap at the originals level'], 422);
+    }
+
+    return $level;
   }
 
   /**

--- a/application/controllers/DrawerPermissions.php
+++ b/application/controllers/DrawerPermissions.php
@@ -4,16 +4,14 @@ if (! defined('BASEPATH')) exit('No direct script access allowed');
 use Doctrine\ORM\EntityManager;
 use Entity\Drawer;
 use Entity\DrawerGroup;
+use Entity\DrawerPermission;
 use Entity\GroupEntry;
+use Entity\Permission;
 use Entity\User;
 use SimpleValidator as V;
 
 /**
  * JSON api for the drawer group/permission management ui.
- *
- * Drawer groups are owned by a user, unlike instance groups which belong
- * to the instance. So every action is scoped to the signed-in user's own
- * groups and gated on "can manage drawers", not instance admin.
  */
 class DrawerPermissions extends Instance_Controller {
   private AuthHelper $authHelper;
@@ -29,9 +27,9 @@ class DrawerPermissions extends Instance_Controller {
   }
 
   /**
-   * GET /drawerPermissions/groupTypes: the catalog for the type selector.
-   * Admin-only types stay in the list so non-admin UIs can show them
-   * disabled, matching the legacy form.
+   * GET /drawerPermissions/groupTypes
+   * List of group types the signed-in user can create.
+   * Some are admin-only.
    */
   public function groupTypes(): CI_Output {
     $this->abortUnlessCanManageDrawers();
@@ -54,13 +52,10 @@ class DrawerPermissions extends Instance_Controller {
   }
 
   /**
-   * GET /drawerPermissions/userAutocomplete?q=... suggests people for a
-   * "Specific People" group's member field. Read only. The twin of
-   * AdminPermissions::userAutocomplete, open to any drawer manager
+   * GET /drawerPermissions/userAutocomplete?q=...
+   * suggests people for a "Specific People" group's member field. The twin of
+   * AdminPermissions::userAutocomplete, except open to any drawer manager
    * instead of instance admins only.
-   *
-   * Every school searches local users. Schools with an external directory
-   * (UMN, St. Olaf) also return matches from central auth.
    */
   public function userAutocomplete(): CI_Output {
     $this->abortUnlessCanManageDrawers();
@@ -76,8 +71,6 @@ class DrawerPermissions extends Instance_Controller {
       return render_json(['matches' => []]);
     }
 
-    // reshape each match for the new UI: a plain list, with the id named
-    // localUserId instead of the legacy completionId
     $matches = array_map(
       fn($match) => [
         "name" => $match["name"],
@@ -92,21 +85,227 @@ class DrawerPermissions extends Instance_Controller {
   }
 
   /**
-   * GET /drawerPermissions/drawers: drawers the signed-in user can
-   * manage, for the management page's Drawers tab.
+   * GET /drawerPermissions/manageableDrawers
+   * Drawers the signed-in user can manage, for the management page's Drawers
+   * tab and the rule editor's drawer picker.
    */
-  public function drawers(): CI_Output {
+  public function manageableDrawers(): CI_Output {
     $this->abortUnlessCanManageDrawers();
+
+    if ($this->input->server('REQUEST_METHOD') !== 'GET') {
+      return abort_json(['error' => 'Method Not Allowed'], 405);
+    }
 
     $drawerPayload = array_map(
       fn(Drawer $drawer) => [
         'id' => $drawer->getId(),
         'title' => $drawer->getTitle(),
       ],
-      $this->manageableDrawers()
+      $this->getManageableDrawers()
     );
 
-    return render_json(['drawers' => $drawerPayload]);
+    return render_json(['manageableDrawers' => $drawerPayload]);
+  }
+
+  /**
+   * /drawerPermissions/grants[/{id}].
+   *
+   * Entry point for ops on a permission grant (aka rule).
+   * A grant is a combination of a drawer, drawergroup, and permission level.
+   *
+   * A user with PERM_CREATEDRAWERS level access on a given drawer
+   * can modify any grant on that drawer, **including grants for groups owned
+   * by other users**. (Same as legacy Drawers::editDrawerPermissions.)
+   */
+  public function grants($grantId = null): CI_Output {
+    $this->abortUnlessCanManageDrawers();
+
+    $method = $this->input->server('REQUEST_METHOD');
+
+    $grantId = $grantId === null
+      ? null
+      : filter_var($grantId, FILTER_VALIDATE_INT);
+
+    // a non-numeric id segment becomes false
+    if ($grantId === false) {
+      return abort_json(['error' => 'Invalid ID'], 400);
+    }
+
+    $route = $grantId === null ? '/grants' : '/grants/{id}';
+
+    $table = [
+      '/grants' => [
+        'GET' => fn() => $this->listGrants(),
+        'POST' => fn() => $this->createGrant(),
+      ],
+      '/grants/{id}' => [
+        'PUT' => fn() => $this->updateGrant($grantId),
+        'PATCH' => fn() => $this->updateGrant($grantId),
+        'DELETE' => fn() => $this->deleteGrant($grantId),
+      ],
+    ];
+
+    $handler = $table[$route][$method] ?? null;
+
+    if ($handler) {
+      return $handler();
+    }
+
+    return abort_json(['error' => 'Method Not Allowed'], 405);
+  }
+
+  /**
+   * GET /drawerPermissions/grants: every grant on every drawer the
+   * caller can manage, for the management page's Rules tab.
+   */
+  private function listGrants(): CI_Output {
+    // grantPayload reads each grant's group and that group's owner, so
+    // select both here rather than let Doctrine lazy-load them one grant
+    // at a time. Left joins: a grant can outlive its group, and a global
+    // group type has no owner.
+    $query = $this->em
+      ->getRepository(DrawerPermission::class)
+      ->createQueryBuilder('drawerGrant')
+      ->addSelect('grantGroup', 'owner')
+      ->join('drawerGrant.drawer', 'drawer')
+      ->leftJoin('drawerGrant.group', 'grantGroup')
+      ->leftJoin('grantGroup.user', 'owner')
+      ->where('drawer.instance = :instance')
+      ->setParameter('instance', $this->instance);
+
+    // if user doesn't manage every drawer (non-admin), limit to only
+    // the drawers they manage
+    if (!$this->canManageEveryDrawer()) {
+      $manageableDrawerIds = $this->manageableDrawerIdsFromPermissionMap();
+
+      // bail early if user manages no drawers
+      if (count($manageableDrawerIds) === 0) {
+        return render_json(['grants' => []]);
+      }
+      $query
+        ->andWhere('drawer.id IN (:manageableDrawerIds)')
+        ->setParameter('manageableDrawerIds', $manageableDrawerIds);
+    }
+
+    return render_json([
+      'grants' => array_map(
+        fn(DrawerPermission $grant) => $this->grantPayload($grant),
+        $query->getQuery()->getResult()
+      ),
+    ]);
+  }
+
+  /**
+   * POST /drawerPermissions/grants: give one of the caller's own groups
+   * a permission level on a drawer they manage.
+   */
+  private function createGrant(): CI_Output {
+    try {
+      $validated = V::validate($this->requestBody(), [
+        'drawerId' => [V::required(), V::integer()],
+        'drawerGroupId' => [V::required(), V::integer()],
+        'permissionLevelId' => [V::required(), V::integer()],
+      ]);
+    } catch (ValidationException $e) {
+      return abort_json(['errors' => $e->getErrors()], 422);
+    }
+
+    $drawer = $this->findManageableDrawerOrAbort((int) $validated['drawerId']);
+
+    // sharing is limited to the caller's own groups
+    $group = $this->findCurrentUserDrawerGroup((int) $validated['drawerGroupId']);
+    if (!$group) {
+      return abort_json(['error' => 'Group not found'], 422);
+    }
+
+    $level = $this->em->find(Permission::class, (int) $validated['permissionLevelId']);
+    if (!$level) {
+      return abort_json(['error' => 'Permission level not found'], 422);
+    }
+
+    $existing = $this->findDrawerPermissionForGroup($drawer, $group);
+    if ($existing) {
+      return abort_json([
+        'error' => 'Group already has a grant on this drawer',
+        'existingGrantId' => $existing->getId(),
+      ], 409);
+    }
+
+    $grant = new DrawerPermission();
+    $grant->setDrawer($drawer);
+    $grant->setGroup($group);
+    $grant->setPermission($level);
+    $this->em->persist($grant);
+
+    // Access computation reads DrawerPermission, but legacy listing paths
+    // still read the drawergroup_drawer M2M, so keep them in sync,
+    // matching Drawers::addDrawer.
+    if (!$this->groupLinksDrawer($group, $drawer)) {
+      $group->addDrawer($drawer);
+    }
+
+    $this->em->flush();
+
+    // the group can match arbitrary users, so their cached permissions
+    // are stale, not just the owner's
+    $this->clearAllUserCache();
+
+    return render_json(['grant' => $this->grantPayload($grant)], 201);
+  }
+
+  /**
+   * PUT|PATCH /drawerPermissions/grants/{id}: change a grant's level.
+   * Drawer manage access is the whole gate, so grants for other owners'
+   * groups are editable too.
+   */
+  private function updateGrant(int $grantId): CI_Output {
+    $grant = $this->findManageableGrantOrAbort($grantId);
+
+    try {
+      $validated = V::validate($this->requestBody(), [
+        'permissionLevelId' => [V::required(), V::integer()],
+      ]);
+    } catch (ValidationException $e) {
+      return abort_json(['errors' => $e->getErrors()], 422);
+    }
+
+    $level = $this->em->find(Permission::class, (int) $validated['permissionLevelId']);
+    if (!$level) {
+      return abort_json(['error' => 'Permission level not found'], 422);
+    }
+
+    // re-level only, the M2M link already exists and stays put
+    $grant->setPermission($level);
+    $this->em->flush();
+    $this->clearAllUserCache();
+
+    return render_json(['grant' => $this->grantPayload($grant)]);
+  }
+
+  /**
+   * DELETE /drawerPermissions/grants/{id}: revoke a grant. Drawer manage
+   * access is the whole gate, matching updateGrant.
+   */
+  private function deleteGrant(int $grantId): CI_Output {
+    $grant = $this->findManageableGrantOrAbort($grantId);
+
+    $drawer = $grant->getDrawer();
+    $group = $grant->getGroup();
+
+    $this->em->remove($grant);
+
+    // The drawergroup_drawer link exists so the group can reach the drawer.
+    // Drop it only when no other grant keeps that true. A stray duplicate
+    // grant (no unique constraint guards concurrent creates) would otherwise
+    // leave a DrawerPermission with its M2M link gone.
+    if ($group && !$this->groupHasOtherGrantOnDrawer($group, $drawer, $grant)) {
+      $group->removeDrawer($drawer);
+    }
+
+    $this->em->flush();
+    $this->clearAllUserCache();
+
+    return render_json(['removed' => $grantId]);
   }
 
   /**
@@ -598,6 +797,129 @@ class DrawerPermissions extends Instance_Controller {
   }
 
   /**
+   * One grant as the Rules tab consumes it: drawerId and
+   * permissionLevelId are id references the caller joins against
+   * /drawers and the permission level catalog. The group rides along
+   * inline because /groups only lists the caller's own groups, so a
+   * grant for another owner's group could not be joined client-side.
+   */
+  private function grantPayload(DrawerPermission $grant): array {
+    $group = $grant->getGroup();
+
+    $groupPayload = null;
+    if ($group !== null) {
+      $groupPayload = [
+        'id' => $group->getId(),
+        'label' => $group->getGroupLabel(),
+        'type' => $group->getGroupType(),
+        'ownedByCurrentUser' => $this->isOwnGroup($group),
+      ];
+    }
+
+    return [
+      'id' => $grant->getId(),
+      'drawerId' => $grant->getDrawer()?->getId(),
+      'permissionLevelId' => $grant->getPermission()?->getId(),
+      'group' => $groupPayload,
+    ];
+  }
+
+  /**
+   * The drawer with `$drawerId` in this instance, aborting 404 when it
+   * does not exist and 403 when the caller cannot manage it.
+   */
+  private function findManageableDrawerOrAbort(int $drawerId): Drawer {
+    $drawer = $this->em
+      ->getRepository(Drawer::class)
+      ->findOneBy(['id' => $drawerId, 'instance' => $this->instance]);
+    if (!$drawer) {
+      abort_json(['error' => 'Drawer not found'], 404);
+    }
+
+    if ($this->user_model->getAccessLevel(DRAWER_PERMISSION, $drawer) < PERM_CREATEDRAWERS) {
+      abort_json(['error' => 'Forbidden'], 403);
+    }
+
+    return $drawer;
+  }
+
+  /**
+   * Find the grant for `$group` on `$drawer`, scanning the drawer's own
+   * permissions so a request cannot address a grant on another drawer.
+   */
+  private function findDrawerPermissionForGroup(
+    Drawer $drawer,
+    DrawerGroup $group
+  ): ?DrawerPermission {
+    foreach ($drawer->getPermissions() as $candidate) {
+      if ($candidate->getGroup()?->getId() === $group->getId()) {
+        return $candidate;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * The grant with `$grantId`, aborting 404 when it does not exist in
+   * this instance and 403 when the caller cannot manage its drawer.
+   */
+  private function findManageableGrantOrAbort(int $grantId): DrawerPermission {
+    $grant = $this->em->find(DrawerPermission::class, $grantId);
+
+    $drawer = $grant?->getDrawer();
+    if (!$drawer) {
+      abort_json(['error' => 'Grant not found'], 404);
+    }
+
+    // the drawer gate owns both the instance scope and the manage level,
+    // so a grant on another instance's drawer aborts 404 there
+    $this->findManageableDrawerOrAbort($drawer->getId());
+
+    return $grant;
+  }
+
+  /**
+   * Whether `$group` still holds a grant on `$drawer` other than
+   * `$excluding`, so delete keeps the M2M link when a stray duplicate
+   * grant remains.
+   */
+  private function groupHasOtherGrantOnDrawer(
+    DrawerGroup $group,
+    Drawer $drawer,
+    DrawerPermission $excluding
+  ): bool {
+    foreach ($drawer->getPermissions() as $candidate) {
+      if ($candidate->getId() === $excluding->getId()) {
+        continue;
+      }
+      if ($candidate->getGroup()?->getId() === $group->getId()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Whether the group already links the drawer through the
+   * drawergroup_drawer M2M, so create adds the link only once.
+   */
+  private function groupLinksDrawer(DrawerGroup $group, Drawer $drawer): bool {
+    foreach ($group->getDrawer() as $candidate) {
+      if ($candidate->getId() === $drawer->getId()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private function isOwnGroup(?DrawerGroup $group): bool {
+    $ownerId = $group?->getUser()?->getId();
+    // compare entity ids on both sides: user_model->userId comes from the
+    // session as a string, so it would never === an int id
+    return $ownerId !== null && $ownerId === $this->user_model->user?->getId();
+  }
+
+  /**
    * Find the entry with `$entryId` among `$group`'s own entries.
    *
    * Entry ids are global, so fetching one straight from the repository
@@ -710,28 +1032,46 @@ class DrawerPermissions extends Instance_Controller {
   }
 
   /**
-   * Drawers the signed-in user holds at least PERM_CREATEDRAWERS on.
+   * Whether the caller manages every drawer in the instance.
    *
    * Instance admins hold PERM_ADMIN on every drawer in their instance
    * through a fallback in getAccessLevel, not through the
-   * drawerPermissions map, so they get the whole instance's drawers here.
+   * drawerPermissions map, so no id list describes their reach.
    */
-  private function manageableDrawers(): array {
+  private function canManageEveryDrawer(): bool {
+    return $this->user_model->isInstanceAdmin()
+      || $this->user_model->getIsSuperAdmin();
+  }
+
+  /**
+   * Ids of the drawers the caller holds at least PERM_CREATEDRAWERS on.
+   * Empty for an instance admin, whose reach comes from the
+   * getAccessLevel fallback instead of the map.
+   */
+  private function manageableDrawerIdsFromPermissionMap(): array {
+    // $this->user_model->drawerPermissions is an assoc. array of
+    // [drawerId => accessLevel], so pluck the ids at manage level
+    return array_keys(array_filter(
+      $this->user_model->drawerPermissions,
+      fn($level) => $level >= PERM_CREATEDRAWERS
+    ));
+  }
+
+  /**
+   * Drawers the signed-in user holds at least PERM_CREATEDRAWERS on,
+   * sorted by title.
+   */
+  private function getManageableDrawers(): array {
     $drawerRepository = $this->em->getRepository(Drawer::class);
 
-    $isEveryDrawerManageable = $this->user_model->isInstanceAdmin()
-      || $this->user_model->getIsSuperAdmin();
-    if ($isEveryDrawerManageable) {
+    if ($this->canManageEveryDrawer()) {
       return $drawerRepository->findBy(
         ['instance' => $this->instance],
         ['title' => 'ASC']
       );
     }
 
-    $manageableDrawerIds = array_keys(array_filter(
-      $this->user_model->drawerPermissions,
-      fn($level) => $level >= PERM_CREATEDRAWERS
-    ));
+    $manageableDrawerIds = $this->manageableDrawerIdsFromPermissionMap();
     if (count($manageableDrawerIds) === 0) {
       return [];
     }

--- a/application/controllers/DrawerPermissions.php
+++ b/application/controllers/DrawerPermissions.php
@@ -837,6 +837,9 @@ class DrawerPermissions extends Instance_Controller {
         'ownedByCurrentUser' => $this->isOwnGroup($group),
         // null for a global group type, which has no owner
         'ownerName' => $group->getUser()?->getDisplayName(),
+        // A User group stores its members as entries, so one count
+        // covers both. A global group type stores neither and counts 0.
+        'entries_count' => $group->getGroupValues()->count(),
       ];
     }
 

--- a/application/controllers/DrawerPermissions.php
+++ b/application/controllers/DrawerPermissions.php
@@ -115,7 +115,7 @@ class DrawerPermissions extends Instance_Controller {
    *
    * A user with PERM_CREATEDRAWERS level access on a given drawer
    * can re-level any grant on that drawer, **including grants for groups owned
-   * by other users**. (Same as legacy Drawers::editDrawerPermissions.)
+   * by other users**. (Same as Permissions::edit under DRAWER_PERMISSION.)
    *
    * Deleting is the exception: it needs the group to be the caller's own.
    * See deleteGrant.
@@ -301,8 +301,8 @@ class DrawerPermissions extends Instance_Controller {
     // put back by the manager who deleted it. Re-levelling it to
     // PERM_NOPERM revokes the access and leaves the grant for its owner,
     // so that is the path the Rules tab offers instead. This is a
-    // deliberate break from legacy Drawers::editDrawerPermissions, which
-    // let a drawer manager delete any grant on their drawer.
+    // deliberate break from Permissions::edit, which lets a drawer
+    // manager delete any grant on their drawer.
     // A grant that outlived its group belongs to nobody, so it stays
     // deletable as cleanup.
     if ($group !== null && !$this->isOwnGroup($group)) {

--- a/application/controllers/DrawerPermissions.php
+++ b/application/controllers/DrawerPermissions.php
@@ -114,8 +114,11 @@ class DrawerPermissions extends Instance_Controller {
    * A grant is a combination of a drawer, drawergroup, and permission level.
    *
    * A user with PERM_CREATEDRAWERS level access on a given drawer
-   * can modify any grant on that drawer, **including grants for groups owned
+   * can re-level any grant on that drawer, **including grants for groups owned
    * by other users**. (Same as legacy Drawers::editDrawerPermissions.)
+   *
+   * Deleting is the exception: it needs the group to be the caller's own.
+   * See deleteGrant.
    */
   public function grants($grantId = null): CI_Output {
     $this->abortUnlessCanManageDrawers();
@@ -283,14 +286,31 @@ class DrawerPermissions extends Instance_Controller {
   }
 
   /**
-   * DELETE /drawerPermissions/grants/{id}: revoke a grant. Drawer manage
-   * access is the whole gate, matching updateGrant.
+   * DELETE /drawerPermissions/grants/{id}: revoke a grant, which drawer
+   * manage access alone does not permit. Unlike updateGrant, the group
+   * must be the caller's own.
    */
   private function deleteGrant(int $grantId): CI_Output {
     $grant = $this->findManageableGrantOrAbort($grantId);
 
     $drawer = $grant->getDrawer();
     $group = $grant->getGroup();
+
+    // Deleting is one-way: createGrant takes only the caller's own
+    // groups, so a grant deleted off someone else's group could not be
+    // put back by the manager who deleted it. Re-levelling it to
+    // PERM_NOPERM revokes the access and leaves the grant for its owner,
+    // so that is the path the Rules tab offers instead. This is a
+    // deliberate break from legacy Drawers::editDrawerPermissions, which
+    // let a drawer manager delete any grant on their drawer.
+    // A grant that outlived its group belongs to nobody, so it stays
+    // deletable as cleanup.
+    if ($group !== null && !$this->isOwnGroup($group)) {
+      return abort_json(
+        ['error' => "Cannot delete another owner's grant"],
+        403
+      );
+    }
 
     $this->em->remove($grant);
 

--- a/application/controllers/DrawerPermissions.php
+++ b/application/controllers/DrawerPermissions.php
@@ -813,6 +813,8 @@ class DrawerPermissions extends Instance_Controller {
         'label' => $group->getGroupLabel(),
         'type' => $group->getGroupType(),
         'ownedByCurrentUser' => $this->isOwnGroup($group),
+        // null for a global group type, which has no owner
+        'ownerName' => $group->getUser()?->getDisplayName(),
       ];
     }
 

--- a/application/controllers/DrawerPermissions.php
+++ b/application/controllers/DrawerPermissions.php
@@ -476,58 +476,24 @@ class DrawerPermissions extends Instance_Controller {
   }
 
   /**
-   * PUT|PATCH /drawerPermissions/groups/{id}: edit a group's label and
-   * type.
+   * PUT|PATCH /drawerPermissions/groups/{id}: rename a group.
    *
-   * Changing the type clears existing entries, since they belong to the
-   * old type. Editing only the label leaves them alone.
+   * A group's type is fixed at creation, since its entries and members
+   * belong to that type. Use a new group to match on something else.
    */
   private function updateGroup(int $groupId): CI_Output {
     $group = $this->findEditableGroupOrAbort($groupId);
 
     try {
-      $validated = V::validate(
-        $this->requestBody(),
-        $this->groupAttributeRules()
-      );
+      $validated = V::validate($this->requestBody(), $this->groupLabelRules());
     } catch (ValidationException $e) {
       return abort_json(['errors' => $e->getErrors()], 422);
     }
 
-    $newType = $validated['type'];
-    $hasTypeChanged = $newType !== $group->getGroupType();
-
-    // a non-admin may keep an admin-only type it already has (rename
-    // only), but may not switch a group onto one
-    if ($hasTypeChanged && !$this->canUseGroupType($newType)) {
-      return abort_json(
-        ['error' => 'Only instance admins can use instance-wide group types'],
-        403
-      );
-    }
-
     $group->setGroupLabel($validated['label']);
-
-    if ($hasTypeChanged) {
-      $group->setGroupType($newType);
-
-      // toArray() copies first so removing entries does not mutate the
-      // list mid-loop
-      foreach ($group->getGroupValues()->toArray() as $entry) {
-        $group->removeGroupValue($entry);
-      }
-      $group->setGroupValue($this->groupTypeCatalog->ignoresGroupValues($newType) ? 1 : null);
-    }
-
     $this->em->flush();
 
-    if ($hasTypeChanged) {
-      // clearing the members revokes their drawer access, so their
-      // cached permissions are stale too, not just the owner's
-      $this->clearAllUserCache();
-    } else {
-      $this->removeCurrentUserCache();
-    }
+    $this->removeCurrentUserCache();
 
     return render_json(['group' => $group]);
   }
@@ -1025,9 +991,7 @@ class DrawerPermissions extends Instance_Controller {
   }
 
   /**
-   * Validation rules for a group's editable attributes (label + type).
-   * The label rejects `< > "` to prevent HTML injection while still
-   * allowing names like `R&D` and `Bob's Team`.
+   * Validation rules for the attributes a group is created with.
    */
   private function groupAttributeRules(): array {
     $validTypes = array_keys($this->groupTypeCatalog->all());
@@ -1038,6 +1002,16 @@ class DrawerPermissions extends Instance_Controller {
           ? true
           : 'Unknown group type',
       ],
+    ] + $this->groupLabelRules();
+  }
+
+  /**
+   * Validation rules for a group's label, which rejects `< > "` to
+   * prevent HTML injection while still allowing names like `R&D` and
+   * `Bob's Team`.
+   */
+  private function groupLabelRules(): array {
+    return [
       'label' => [
         V::required(),
         V::maxLength(255),

--- a/application/controllers/DrawerPermissions.php
+++ b/application/controllers/DrawerPermissions.php
@@ -288,7 +288,7 @@ class DrawerPermissions extends Instance_Controller {
   /**
    * DELETE /drawerPermissions/grants/{id}: revoke a grant, which drawer
    * manage access alone does not permit. Unlike updateGrant, the group
-   * must be the caller's own.
+   * must be the caller's own, unless they are an admin.
    */
   private function deleteGrant(int $grantId): CI_Output {
     $grant = $this->findManageableGrantOrAbort($grantId);
@@ -300,12 +300,14 @@ class DrawerPermissions extends Instance_Controller {
     // groups, so a grant deleted off someone else's group could not be
     // put back by the manager who deleted it. Re-levelling it to
     // PERM_NOPERM revokes the access and leaves the grant for its owner,
-    // so that is the path the Rules tab offers instead. This is a
-    // deliberate break from Permissions::edit, which lets a drawer
+    // so that is the path the Rules tab offers a manager instead. This is
+    // a deliberate break from Permissions::edit, which lets a drawer
     // manager delete any grant on their drawer.
-    // A grant that outlived its group belongs to nobody, so it stays
-    // deletable as cleanup.
-    if ($group !== null && !$this->isOwnGroup($group)) {
+    // Admins reach every drawer and are trusted with the cleanup, so the
+    // rule binds managers only. A grant that outlived its group belongs
+    // to nobody, so it stays deletable too.
+    $isAnotherOwnersGrant = $group !== null && !$this->isOwnGroup($group);
+    if ($isAnotherOwnersGrant && !$this->canManageEveryDrawer()) {
       return abort_json(
         ['error' => "Cannot delete another owner's grant"],
         403

--- a/application/controllers/Permissions.php
+++ b/application/controllers/Permissions.php
@@ -97,7 +97,10 @@ class Permissions extends Instance_Controller {
 	public function permissionLevels() {
 		$this->abortUnlessAuthed();
 
-		$permissionLevels = $this->doctrine->em->getRepository(Permission::class)->findBy([], ["level" => "ASC"]);
+		$permissionLevels = $this->doctrine->em->getRepository(Permission::class)->findAll();
+
+		// level is a string column, so "10" sorts before "5" unless we compare numerically
+		usort($permissionLevels, fn($a, $b) => (int) $a->getLevel() <=> (int) $b->getLevel());
 
 		return render_json([
 			'permissionLevels' => $permissionLevels,

--- a/tests/api/drawerGroups.spec.ts
+++ b/tests/api/drawerGroups.spec.ts
@@ -176,7 +176,7 @@ test.describe("drawerPermissions", () => {
     for (const path of [
       "/drawerPermissions/groupTypes",
       "/drawerPermissions/userAutocomplete?q=ab",
-      "/drawerPermissions/drawers",
+      "/drawerPermissions/manageableDrawers",
       "/drawerPermissions/groups",
       "/drawerPermissions/groups/1",
       "/drawerPermissions/groups/1/members",
@@ -276,15 +276,6 @@ test.describe("drawerPermissions", () => {
       for (const group of groups) {
         expect(typeof group.is_personal).toBe("boolean");
       }
-    });
-
-    test("GET /drawers returns a drawers array", async ({ page }) => {
-      const res = await page.request.get(
-        `${baseURL()}/drawerPermissions/drawers`,
-        { headers: { Accept: "application/json" } }
-      );
-      expect(res.status()).toBe(200);
-      expect(Array.isArray((await res.json()).drawers)).toBe(true);
     });
 
     test("unsupported verb on /groups returns 405", async ({ page }) => {

--- a/tests/api/drawerGroups.spec.ts
+++ b/tests/api/drawerGroups.spec.ts
@@ -410,7 +410,7 @@ test.describe("drawerPermissions", () => {
       expect(res.status()).toBe(403);
     });
 
-    test("may not switch a group onto an admin-only type", async ({ page }) => {
+    test("cannot move a group onto an admin-only type", async ({ page }) => {
       const label = uniqueLabel("Switcher");
       const group = await createDrawerGroup(page, { type: "User", label });
 
@@ -418,7 +418,10 @@ test.describe("drawerPermissions", () => {
         `${baseURL()}/drawerPermissions/groups/${group.id}`,
         { form: { type: "Authed", label } }
       );
-      expect(res.status()).toBe(403);
+      expect(res.status()).toBe(200);
+
+      const { group: updated } = await res.json();
+      expect(updated.type).toBe("User");
     });
 
     test("cannot see or mutate another user's group", async ({
@@ -505,7 +508,7 @@ test.describe("drawerPermissions", () => {
       await loginAdmin(page);
     });
 
-    test("renames a group, keeping its type", async ({ page }) => {
+    test("renames a group", async ({ page }) => {
       const group = await createDrawerGroup(page, {
         type: "User",
         label: uniqueLabel("Before"),
@@ -514,7 +517,7 @@ test.describe("drawerPermissions", () => {
       const after = uniqueLabel("After");
       const res = await page.request.patch(
         `${baseURL()}/drawerPermissions/groups/${group.id}`,
-        { form: { type: "User", label: after } }
+        { form: { label: after } }
       );
       expect(res.status()).toBe(200);
 
@@ -523,7 +526,7 @@ test.describe("drawerPermissions", () => {
       expect(updated.type).toBe("User");
     });
 
-    test("changing the type clears existing members", async ({ page }) => {
+    test("ignores a type in the body, keeping members", async ({ page }) => {
       const label = uniqueLabel("Movers");
       const group = await createDrawerGroup(page, { type: "User", label });
       const admin = await findUserByUsername(page, "admin");
@@ -539,14 +542,14 @@ test.describe("drawerPermissions", () => {
       expect(res.status()).toBe(200);
 
       const { group: updated } = await res.json();
-      expect(updated.type).toBe("Authed");
-      expect(updated.entries_count).toBe(0);
+      expect(updated.type).toBe("User");
+      expect(updated.entries_count).toBe(1);
     });
 
     test("returns 404 for a missing group", async ({ page }) => {
       const res = await page.request.patch(
         `${baseURL()}/drawerPermissions/groups/99999999`,
-        { form: { type: "User", label: "Nope" } }
+        { form: { label: "Nope" } }
       );
       expect(res.status()).toBe(404);
     });
@@ -559,7 +562,7 @@ test.describe("drawerPermissions", () => {
 
       const res = await page.request.patch(
         `${baseURL()}/drawerPermissions/groups/${group.id}`,
-        { form: { type: "User", label: "bad <script>" } }
+        { form: { label: "bad <script>" } }
       );
       expect(res.status()).toBe(422);
       expect((await res.json()).errors).toHaveProperty("label");

--- a/tests/api/drawerPermissions.spec.ts
+++ b/tests/api/drawerPermissions.spec.ts
@@ -171,6 +171,7 @@ type Grant = {
     label: string;
     type: string;
     ownedByCurrentUser: boolean;
+    ownerName: string | null;
   } | null;
 };
 
@@ -308,14 +309,16 @@ test.describe("drawerPermissions grants", () => {
       );
       expect(created.status()).toBe(201);
       const adminGrant = (await created.json()).grant as Grant;
+      const adminName = (await findUserByUsername(adminPage, "admin")).name;
       await adminContext.close();
 
-      // the manager sees the grant, labeled as another owner's group
+      // the manager sees the grant, labeled with the owner it belongs to
       const listed = (await listGrants(page)).find(
         (g) => g.id === adminGrant.id,
       );
       expect(listed).toBeTruthy();
       expect(listed?.group?.ownedByCurrentUser).toBe(false);
+      expect(listed?.group?.ownerName).toBe(adminName);
 
       // and can re-level and revoke it despite not owning the group
       const newLevel = levels[levels.length - 1];

--- a/tests/api/drawerPermissions.spec.ts
+++ b/tests/api/drawerPermissions.spec.ts
@@ -1,0 +1,439 @@
+import {
+  test,
+  expect,
+  type APIResponse,
+  type Browser,
+  type Page,
+} from "@playwright/test";
+import { loginUser, createUser, baseURL } from "../helpers";
+
+// Grant endpoints under DrawerPermissions.php, routed at
+// /{instance}/drawerPermissions/grants[/{id}]. A grant gives one drawer
+// group a permission level on one drawer. Grants are scoped by drawer, not
+// group owner: the listing spans every drawer the caller can manage, and
+// update/delete work on any grant there, including grants for groups owned
+// by other users. Only creation is limited to the caller's own groups.
+//
+// reset-test-db.sh never truncates users, groups, or grants, so fixture users
+// are find-or-create and labels carry a per-run tag.
+
+const runTag = Date.now().toString(36);
+
+function uniqueLabel(name: string): string {
+  return `${name} ${runTag}`;
+}
+
+const NON_MANAGER = {
+  username: "e2e-no-drawer-access",
+  password: "e2e-no-drawer-access",
+};
+
+// granted instance-wide createDrawers via a group, not admin
+const DRAWER_MANAGER = {
+  username: "e2e-drawer-manager",
+  password: "e2e-drawer-manager",
+};
+
+const MANAGER_GRANT_GROUP_LABEL = "Drawer Managers (e2e)";
+
+async function loginAdmin(page: Page) {
+  await loginUser(page, "admin");
+}
+
+type UserMatch = {
+  name: string;
+  email: string;
+  localUserId: number;
+  username: string;
+};
+
+async function findUserByUsername(
+  page: Page,
+  username: string,
+): Promise<UserMatch> {
+  const res = await page.request.get(
+    `${baseURL()}/adminPermissions/userAutocomplete?q=${encodeURIComponent(
+      username,
+    )}`,
+    { headers: { Accept: "application/json" } },
+  );
+  expect(res.status()).toBe(200);
+  const { matches } = (await res.json()) as { matches: UserMatch[] };
+  const match = matches.find((m) => m.username === username);
+  expect(match, `no autocomplete match for "${username}"`).toBeTruthy();
+  return match as UserMatch;
+}
+
+type PermissionLevel = { id: number; level: number };
+
+// /permissions/permissionLevels is open to any authed user, unlike the
+// admin-only /adminPermissions one, so a drawer manager can read it too.
+async function getPermissionLevels(page: Page): Promise<PermissionLevel[]> {
+  const res = await page.request.get(
+    `${baseURL()}/permissions/permissionLevels`,
+    { headers: { Accept: "application/json" } },
+  );
+  expect(res.status()).toBe(200);
+  const { permissionLevels } = (await res.json()) as {
+    permissionLevels: PermissionLevel[];
+  };
+  return permissionLevels;
+}
+
+async function ensureNonManagerUser(browser: Browser): Promise<void> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await loginAdmin(page);
+  await createUser(page, NON_MANAGER.username, NON_MANAGER.password);
+  await context.close();
+}
+
+// The manager's createDrawers level rides on an instance group with them as
+// its one member, mirroring drawerGroups.spec.ts so the two specs share the
+// find-or-create fixture.
+async function ensureDrawerManagerUser(browser: Browser): Promise<void> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await loginAdmin(page);
+  await createUser(page, DRAWER_MANAGER.username, DRAWER_MANAGER.password);
+
+  const listRes = await page.request.get(
+    `${baseURL()}/adminPermissions/groups`,
+    { headers: { Accept: "application/json" } },
+  );
+  expect(listRes.status()).toBe(200);
+  const { groups } = (await listRes.json()) as {
+    groups: { id: number; label: string }[];
+  };
+
+  if (groups.some((g) => g.label === MANAGER_GRANT_GROUP_LABEL)) {
+    await context.close();
+    return;
+  }
+
+  const createRes = await page.request.post(
+    `${baseURL()}/adminPermissions/groups`,
+    { form: { type: "User", label: MANAGER_GRANT_GROUP_LABEL } },
+  );
+  expect(createRes.status()).toBe(201);
+  const { group } = (await createRes.json()) as { group: { id: number } };
+
+  const manager = await findUserByUsername(page, DRAWER_MANAGER.username);
+  const memberRes = await page.request.post(
+    `${baseURL()}/adminPermissions/groups/${group.id}/members`,
+    { form: { localUserId: String(manager.localUserId) } },
+  );
+  expect(memberRes.status()).toBe(201);
+
+  const levels = await getPermissionLevels(page);
+  const createDrawers = levels.find((p) => Number(p.level) === 30);
+  expect(createDrawers, "seed DB lacks the createDrawers level").toBeTruthy();
+
+  const grantRes = await page.request.post(
+    `${baseURL()}/adminPermissions/instanceGrants`,
+    {
+      form: {
+        groupId: String(group.id),
+        permissionLevelId: String(createDrawers?.id),
+      },
+    },
+  );
+  expect(grantRes.status()).toBe(201);
+
+  await context.close();
+}
+
+// Drawers::addDrawer auto-creates the owner's personal drawer group and a
+// createDrawers grant for it, so a fresh drawer already has one grant.
+async function createDrawer(page: Page, title: string): Promise<number> {
+  const res = await page.request.post(`${baseURL()}/drawers/addDrawer`, {
+    headers: { Accept: "application/json" },
+    form: { drawerTitle: title },
+  });
+  expect(res.status()).toBe(200);
+  return (await res.json()).drawerId as number;
+}
+
+async function createDrawerGroup(page: Page, label: string): Promise<number> {
+  const res = await page.request.post(`${baseURL()}/drawerPermissions/groups`, {
+    form: { type: "User", label },
+  });
+  expect(res.status()).toBe(201);
+  return (await res.json()).group.id as number;
+}
+
+type Grant = {
+  id: number;
+  drawerId: number;
+  permissionLevelId: number;
+  group: {
+    id: number;
+    label: string;
+    type: string;
+    ownedByCurrentUser: boolean;
+  } | null;
+};
+
+async function listGrants(page: Page): Promise<Grant[]> {
+  const res = await page.request.get(`${baseURL()}/drawerPermissions/grants`, {
+    headers: { Accept: "application/json" },
+  });
+  expect(res.status()).toBe(200);
+  return (await res.json()).grants as Grant[];
+}
+
+async function createGrant(
+  page: Page,
+  drawerId: number,
+  drawerGroupId: number,
+  permissionLevelId: number,
+): Promise<APIResponse> {
+  return page.request.post(`${baseURL()}/drawerPermissions/grants`, {
+    form: {
+      drawerId: String(drawerId),
+      drawerGroupId: String(drawerGroupId),
+      permissionLevelId: String(permissionLevelId),
+    },
+  });
+}
+
+test.describe("drawerPermissions grants", () => {
+  test.describe("unauthenticated", () => {
+    for (const path of [
+      "/drawerPermissions/grants",
+      "/drawerPermissions/grants/1",
+    ]) {
+      test(`GET ${path} returns 401`, async ({ page }) => {
+        const res = await page.request.get(`${baseURL()}${path}`, {
+          headers: { Accept: "application/json" },
+        });
+        expect(res.status()).toBe(401);
+      });
+    }
+  });
+
+  test.describe("without drawer access", () => {
+    test.beforeAll(async ({ browser }) => {
+      await ensureNonManagerUser(browser);
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await loginUser(page, NON_MANAGER.username, NON_MANAGER.password);
+    });
+
+    test("GET grants returns 403", async ({ page }) => {
+      const res = await page.request.get(
+        `${baseURL()}/drawerPermissions/grants`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(res.status()).toBe(403);
+    });
+  });
+
+  test.describe("as a drawer manager", () => {
+    test.beforeAll(async ({ browser }) => {
+      await ensureDrawerManagerUser(browser);
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await loginUser(page, DRAWER_MANAGER.username, DRAWER_MANAGER.password);
+    });
+
+    test("a fresh drawer lists its auto-created personal grant", async ({
+      page,
+    }) => {
+      const drawerId = await createDrawer(page, uniqueLabel("Fresh Drawer"));
+      const drawerGrants = (await listGrants(page)).filter(
+        (g) => g.drawerId === drawerId,
+      );
+      expect(drawerGrants.length).toBeGreaterThanOrEqual(1);
+      expect(drawerGrants.every((g) => g.group?.ownedByCurrentUser)).toBe(true);
+    });
+
+    test("creates, lists, re-levels, and deletes a grant", async ({ page }) => {
+      const drawerId = await createDrawer(page, uniqueLabel("CRUD Drawer"));
+      const groupId = await createDrawerGroup(page, uniqueLabel("CRUD Group"));
+      const levels = await getPermissionLevels(page);
+
+      const created = await createGrant(page, drawerId, groupId, levels[0].id);
+      expect(created.status()).toBe(201);
+      const grant = (await created.json()).grant as Grant;
+      expect(grant.drawerId).toBe(drawerId);
+      expect(grant.group?.id).toBe(groupId);
+      expect(grant.permissionLevelId).toBe(levels[0].id);
+
+      const afterCreate = await listGrants(page);
+      expect(afterCreate.some((g) => g.id === grant.id)).toBe(true);
+
+      const newLevel = levels[levels.length - 1];
+      const updated = await page.request.put(
+        `${baseURL()}/drawerPermissions/grants/${grant.id}`,
+        { form: { permissionLevelId: String(newLevel.id) } },
+      );
+      expect(updated.status()).toBe(200);
+      expect((await updated.json()).grant.permissionLevelId).toBe(newLevel.id);
+
+      const removed = await page.request.delete(
+        `${baseURL()}/drawerPermissions/grants/${grant.id}`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(removed.status()).toBe(200);
+      expect((await removed.json()).removed).toBe(grant.id);
+
+      const afterDelete = await listGrants(page);
+      expect(afterDelete.some((g) => g.id === grant.id)).toBe(false);
+    });
+
+    test("re-levels and deletes another owner's grant on a managed drawer", async ({
+      page,
+      browser,
+    }) => {
+      const drawerId = await createDrawer(page, uniqueLabel("Shared Drawer"));
+      const levels = await getPermissionLevels(page);
+
+      // the admin (who manages every drawer) grants their own group access
+      // to the manager's drawer
+      const adminContext = await browser.newContext();
+      const adminPage = await adminContext.newPage();
+      await loginAdmin(adminPage);
+      const adminGroupId = await createDrawerGroup(
+        adminPage,
+        uniqueLabel("Admin Group"),
+      );
+      const created = await createGrant(
+        adminPage,
+        drawerId,
+        adminGroupId,
+        levels[0].id,
+      );
+      expect(created.status()).toBe(201);
+      const adminGrant = (await created.json()).grant as Grant;
+      await adminContext.close();
+
+      // the manager sees the grant, labeled as another owner's group
+      const listed = (await listGrants(page)).find(
+        (g) => g.id === adminGrant.id,
+      );
+      expect(listed).toBeTruthy();
+      expect(listed?.group?.ownedByCurrentUser).toBe(false);
+
+      // and can re-level and revoke it despite not owning the group
+      const newLevel = levels[levels.length - 1];
+      const updated = await page.request.put(
+        `${baseURL()}/drawerPermissions/grants/${adminGrant.id}`,
+        { form: { permissionLevelId: String(newLevel.id) } },
+      );
+      expect(updated.status()).toBe(200);
+
+      const removed = await page.request.delete(
+        `${baseURL()}/drawerPermissions/grants/${adminGrant.id}`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(removed.status()).toBe(200);
+    });
+
+    // The flat /grants/{id} route makes every grant id addressable, so the
+    // per-drawer check is the only thing scoping a manager to their own
+    // drawers. The route gate passes anyone who manages any drawer at all.
+    test("rejects mutating a grant on a drawer the caller cannot manage", async ({
+      page,
+      browser,
+    }) => {
+      // the admin's own drawer, which the manager holds no permission on
+      const adminContext = await browser.newContext();
+      const adminPage = await adminContext.newPage();
+      await loginAdmin(adminPage);
+      const adminDrawerId = await createDrawer(
+        adminPage,
+        uniqueLabel("Admin Only Drawer"),
+      );
+      // addDrawer auto-creates the owner's personal grant on it
+      const adminGrant = (await listGrants(adminPage)).find(
+        (g) => g.drawerId === adminDrawerId,
+      );
+      expect(adminGrant, "admin's fresh drawer has no grant to target").toBeTruthy();
+      const levels = await getPermissionLevels(adminPage);
+      await adminContext.close();
+
+      // the manager can manage some drawer, so they clear the route gate,
+      // but this grant's drawer is not one of them
+      expect((await listGrants(page)).some((g) => g.id === adminGrant?.id)).toBe(
+        false,
+      );
+
+      const updated = await page.request.put(
+        `${baseURL()}/drawerPermissions/grants/${adminGrant?.id}`,
+        { form: { permissionLevelId: String(levels[0].id) } },
+      );
+      expect(updated.status()).toBe(403);
+
+      const removed = await page.request.delete(
+        `${baseURL()}/drawerPermissions/grants/${adminGrant?.id}`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(removed.status()).toBe(403);
+    });
+
+    test("rejects a second grant for the same group with 409", async ({
+      page,
+    }) => {
+      const drawerId = await createDrawer(page, uniqueLabel("Dupe Drawer"));
+      const groupId = await createDrawerGroup(page, uniqueLabel("Dupe Group"));
+      const levels = await getPermissionLevels(page);
+
+      const first = await createGrant(page, drawerId, groupId, levels[0].id);
+      expect(first.status()).toBe(201);
+      const existingId = (await first.json()).grant.id;
+
+      const second = await createGrant(page, drawerId, groupId, levels[0].id);
+      expect(second.status()).toBe(409);
+      expect((await second.json()).existingGrantId).toBe(existingId);
+    });
+
+    test("rejects an unknown group or level with 422, unknown drawer with 404", async ({
+      page,
+    }) => {
+      const drawerId = await createDrawer(
+        page,
+        uniqueLabel("Validation Drawer"),
+      );
+      const groupId = await createDrawerGroup(page, uniqueLabel("Val Group"));
+      const levels = await getPermissionLevels(page);
+
+      const badGroup = await createGrant(page, drawerId, 99999999, levels[0].id);
+      expect(badGroup.status()).toBe(422);
+
+      const badLevel = await createGrant(page, drawerId, groupId, 99999999);
+      expect(badLevel.status()).toBe(422);
+
+      const badDrawer = await createGrant(page, 99999999, groupId, levels[0].id);
+      expect(badDrawer.status()).toBe(404);
+    });
+
+    test("updating or deleting a missing grant returns 404", async ({
+      page,
+    }) => {
+      const levels = await getPermissionLevels(page);
+
+      const update = await page.request.put(
+        `${baseURL()}/drawerPermissions/grants/99999999`,
+        { form: { permissionLevelId: String(levels[0].id) } },
+      );
+      expect(update.status()).toBe(404);
+
+      const remove = await page.request.delete(
+        `${baseURL()}/drawerPermissions/grants/99999999`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(remove.status()).toBe(404);
+    });
+
+    test("returns 400 for a non-numeric id", async ({ page }) => {
+      const res = await page.request.delete(
+        `${baseURL()}/drawerPermissions/grants/not-a-number`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(res.status()).toBe(400);
+    });
+  });
+});

--- a/tests/api/drawerPermissions.spec.ts
+++ b/tests/api/drawerPermissions.spec.ts
@@ -66,6 +66,13 @@ async function findUserByUsername(
 
 type PermissionLevel = { id: number; level: number };
 
+// Levels arrive sorted ascending, so this is the strongest level a drawer
+// grant accepts: grants cap at originals (level 40), matching legacy.
+function highestGrantableLevel(levels: PermissionLevel[]): PermissionLevel {
+  const grantable = levels.filter((l) => Number(l.level) <= 40);
+  return grantable[grantable.length - 1];
+}
+
 // /permissions/permissionLevels is open to any authed user, unlike the
 // admin-only /adminPermissions one, so a drawer manager can read it too.
 async function getPermissionLevels(page: Page): Promise<PermissionLevel[]> {
@@ -267,7 +274,7 @@ test.describe("drawerPermissions grants", () => {
       const afterCreate = await listGrants(page);
       expect(afterCreate.some((g) => g.id === grant.id)).toBe(true);
 
-      const newLevel = levels[levels.length - 1];
+      const newLevel = highestGrantableLevel(levels);
       const updated = await page.request.put(
         `${baseURL()}/drawerPermissions/grants/${grant.id}`,
         { form: { permissionLevelId: String(newLevel.id) } },
@@ -284,6 +291,41 @@ test.describe("drawerPermissions grants", () => {
 
       const afterDelete = await listGrants(page);
       expect(afterDelete.some((g) => g.id === grant.id)).toBe(false);
+    });
+
+    test("rejects a level above originals on create and update", async ({
+      page,
+    }) => {
+      const drawerId = await createDrawer(page, uniqueLabel("Capped Drawer"));
+      const groupId = await createDrawerGroup(page, uniqueLabel("Capped Group"));
+      const levels = await getPermissionLevels(page);
+
+      const found = levels.find((l) => Number(l.level) > 40);
+      expect(found, "seed DB lacks a level above originals").toBeTruthy();
+      const levelAboveOriginals = found as PermissionLevel;
+
+      const created = await createGrant(
+        page,
+        drawerId,
+        groupId,
+        levelAboveOriginals.id,
+      );
+      expect(created.status()).toBe(422);
+
+      const grantable = highestGrantableLevel(levels);
+      const allowed = await createGrant(page, drawerId, groupId, grantable.id);
+      expect(allowed.status()).toBe(201);
+      const grantId = (await allowed.json()).grant.id as number;
+
+      const updated = await page.request.put(
+        `${baseURL()}/drawerPermissions/grants/${grantId}`,
+        { form: { permissionLevelId: String(levelAboveOriginals.id) } },
+      );
+      expect(updated.status()).toBe(422);
+
+      // the refused update leaves the grant at its old level
+      const survivor = (await listGrants(page)).find((g) => g.id === grantId);
+      expect(survivor?.permissionLevelId).toBe(grantable.id);
     });
 
     test("re-levels but cannot delete another owner's grant on a managed drawer", async ({
@@ -322,7 +364,7 @@ test.describe("drawerPermissions grants", () => {
       expect(listed?.group?.ownerName).toBe(adminName);
 
       // and can re-level it despite not owning the group
-      const newLevel = levels[levels.length - 1];
+      const newLevel = highestGrantableLevel(levels);
       const updated = await page.request.put(
         `${baseURL()}/drawerPermissions/grants/${adminGrant.id}`,
         { form: { permissionLevelId: String(newLevel.id) } },

--- a/tests/api/drawerPermissions.spec.ts
+++ b/tests/api/drawerPermissions.spec.ts
@@ -285,7 +285,7 @@ test.describe("drawerPermissions grants", () => {
       expect(afterDelete.some((g) => g.id === grant.id)).toBe(false);
     });
 
-    test("re-levels and deletes another owner's grant on a managed drawer", async ({
+    test("re-levels but cannot delete another owner's grant on a managed drawer", async ({
       page,
       browser,
     }) => {
@@ -320,7 +320,7 @@ test.describe("drawerPermissions grants", () => {
       expect(listed?.group?.ownedByCurrentUser).toBe(false);
       expect(listed?.group?.ownerName).toBe(adminName);
 
-      // and can re-level and revoke it despite not owning the group
+      // and can re-level it despite not owning the group
       const newLevel = levels[levels.length - 1];
       const updated = await page.request.put(
         `${baseURL()}/drawerPermissions/grants/${adminGrant.id}`,
@@ -328,11 +328,19 @@ test.describe("drawerPermissions grants", () => {
       );
       expect(updated.status()).toBe(200);
 
+      // but not delete it, which they could not undo: a new grant can
+      // only name a group they own. Re-levelling to noperm is the revoke.
       const removed = await page.request.delete(
         `${baseURL()}/drawerPermissions/grants/${adminGrant.id}`,
         { headers: { Accept: "application/json" } },
       );
-      expect(removed.status()).toBe(200);
+      expect(removed.status()).toBe(403);
+
+      // the grant survives the refused delete
+      const survivor = (await listGrants(page)).find(
+        (g) => g.id === adminGrant.id,
+      );
+      expect(survivor?.permissionLevelId).toBe(newLevel.id);
     });
 
     // The flat /grants/{id} route makes every grant id addressable, so the

--- a/tests/api/drawerPermissions.spec.ts
+++ b/tests/api/drawerPermissions.spec.ts
@@ -52,7 +52,7 @@ async function findUserByUsername(
   username: string,
 ): Promise<UserMatch> {
   const res = await page.request.get(
-    `${baseURL()}/adminPermissions/userAutocomplete?q=${encodeURIComponent(
+    `${baseURL()}/drawerPermissions/userAutocomplete?q=${encodeURIComponent(
       username,
     )}`,
     { headers: { Accept: "application/json" } },
@@ -234,6 +234,7 @@ test.describe("drawerPermissions grants", () => {
   test.describe("as a drawer manager", () => {
     test.beforeAll(async ({ browser }) => {
       await ensureDrawerManagerUser(browser);
+      await ensureNonManagerUser(browser);
     });
 
     test.beforeEach(async ({ page }) => {
@@ -455,6 +456,32 @@ test.describe("drawerPermissions grants", () => {
       expect(badDrawer.status()).toBe(404);
     });
 
+    test("rejects a grant naming another user's real group with 422", async ({
+      page,
+      browser,
+    }) => {
+      const drawerId = await createDrawer(page, uniqueLabel("Own Drawer"));
+      const levels = await getPermissionLevels(page);
+
+      const adminContext = await browser.newContext();
+      const adminPage = await adminContext.newPage();
+      await loginAdmin(adminPage);
+      const foreignGroupId = await createDrawerGroup(
+        adminPage,
+        uniqueLabel("Foreign Group"),
+      );
+      await adminContext.close();
+
+      // same refusal as a bogus id: another owner's group is not findable
+      const res = await createGrant(
+        page,
+        drawerId,
+        foreignGroupId,
+        levels[0].id,
+      );
+      expect(res.status()).toBe(422);
+    });
+
     test("updating or deleting a missing grant returns 404", async ({
       page,
     }) => {
@@ -480,5 +507,167 @@ test.describe("drawerPermissions grants", () => {
       );
       expect(res.status()).toBe(400);
     });
+
+    test("a grant opens the drawer to the group's members until deleted", async ({
+      page,
+      browser,
+    }) => {
+      const drawerId = await createDrawer(page, uniqueLabel("Access Drawer"));
+      const groupId = await createDrawerGroup(page, uniqueLabel("Access Group"));
+
+      const member = await findUserByUsername(page, NON_MANAGER.username);
+      const memberRes = await page.request.post(
+        `${baseURL()}/drawerPermissions/groups/${groupId}/members`,
+        { form: { localUserId: String(member.localUserId) } },
+      );
+      expect(memberRes.status()).toBe(201);
+
+      // a viewing level, so the member gains the drawer without becoming
+      // a drawer manager and breaking the without-drawer-access tests
+      const levels = await getPermissionLevels(page);
+      const viewLevel = levels.find(
+        (l) => Number(l.level) > 0 && Number(l.level) < 30,
+      );
+      expect(viewLevel, "seed DB lacks a sub-manage level").toBeTruthy();
+
+      const created = await createGrant(
+        page,
+        drawerId,
+        groupId,
+        (viewLevel as PermissionLevel).id,
+      );
+      expect(created.status()).toBe(201);
+      const grantId = (await created.json()).grant.id as number;
+
+      const memberContext = await browser.newContext();
+      const memberPage = await memberContext.newPage();
+      await loginUser(memberPage, NON_MANAGER.username, NON_MANAGER.password);
+
+      const withGrant = await memberPage.request.get(
+        `${baseURL()}/drawers/listDrawers/true`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(withGrant.status()).toBe(200);
+      const visibleDrawers = (await withGrant.json()) as Record<
+        string,
+        { title: string }
+      >;
+      expect(Object.keys(visibleDrawers)).toContain(String(drawerId));
+
+      const removed = await page.request.delete(
+        `${baseURL()}/drawerPermissions/grants/${grantId}`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(removed.status()).toBe(200);
+
+      const withoutGrant = await memberPage.request.get(
+        `${baseURL()}/drawers/listDrawers/true`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(withoutGrant.status()).toBe(200);
+      const remainingDrawers = (await withoutGrant.json()) as Record<
+        string,
+        { title: string }
+      >;
+      expect(Object.keys(remainingDrawers)).not.toContain(String(drawerId));
+      await memberContext.close();
+    });
+  });
+});
+
+test.describe("drawerPermissions manageableDrawers", () => {
+  test.beforeAll(async ({ browser }) => {
+    await ensureDrawerManagerUser(browser);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await loginUser(page, DRAWER_MANAGER.username, DRAWER_MANAGER.password);
+  });
+
+  test("lists the caller's manageable drawers", async ({ page }) => {
+    const title = uniqueLabel("Listable Drawer");
+    const drawerId = await createDrawer(page, title);
+
+    const res = await page.request.get(
+      `${baseURL()}/drawerPermissions/manageableDrawers`,
+      { headers: { Accept: "application/json" } },
+    );
+    expect(res.status()).toBe(200);
+
+    const { manageableDrawers } = (await res.json()) as {
+      manageableDrawers: { id: number; title: string }[];
+    };
+    const created = manageableDrawers.find((d) => d.id === drawerId);
+    expect(created?.title).toBe(title);
+  });
+
+  test("rejects a non-GET verb with 405", async ({ page }) => {
+    const res = await page.request.post(
+      `${baseURL()}/drawerPermissions/manageableDrawers`,
+      { form: {} },
+    );
+    expect(res.status()).toBe(405);
+  });
+
+  test("an admin sees drawers beyond their own", async ({ page, browser }) => {
+    const managerDrawerId = await createDrawer(
+      page,
+      uniqueLabel("Manager Reach Drawer"),
+    );
+
+    const adminContext = await browser.newContext();
+    const adminPage = await adminContext.newPage();
+    await loginAdmin(adminPage);
+    const adminDrawerId = await createDrawer(
+      adminPage,
+      uniqueLabel("Admin Reach Drawer"),
+    );
+
+    const adminRes = await adminPage.request.get(
+      `${baseURL()}/drawerPermissions/manageableDrawers`,
+      { headers: { Accept: "application/json" } },
+    );
+    expect(adminRes.status()).toBe(200);
+    const adminList = (await adminRes.json()) as {
+      manageableDrawers: { id: number }[];
+    };
+    expect(
+      adminList.manageableDrawers.some((d) => d.id === managerDrawerId),
+    ).toBe(true);
+    await adminContext.close();
+
+    // the manager's reach stays limited to their own drawers
+    const managerRes = await page.request.get(
+      `${baseURL()}/drawerPermissions/manageableDrawers`,
+      { headers: { Accept: "application/json" } },
+    );
+    expect(managerRes.status()).toBe(200);
+    const managerList = (await managerRes.json()) as {
+      manageableDrawers: { id: number }[];
+    };
+    expect(
+      managerList.manageableDrawers.some((d) => d.id === adminDrawerId),
+    ).toBe(false);
+  });
+});
+
+test.describe("permission levels", () => {
+  test.beforeAll(async ({ browser }) => {
+    await ensureDrawerManagerUser(browser);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await loginUser(page, DRAWER_MANAGER.username, DRAWER_MANAGER.password);
+  });
+
+  // level is a string column upstream, so "10" would sort before "5"
+  // without the numeric comparison
+  test("arrive in ascending numeric order", async ({ page }) => {
+    const levels = await getPermissionLevels(page);
+    expect(levels.length).toBeGreaterThan(1);
+
+    const numericLevels = levels.map((l) => Number(l.level));
+    const ascending = [...numericLevels].sort((a, b) => a - b);
+    expect(numericLevels).toEqual(ascending);
   });
 });

--- a/tests/api/drawerPermissions.spec.ts
+++ b/tests/api/drawerPermissions.spec.ts
@@ -343,6 +343,40 @@ test.describe("drawerPermissions grants", () => {
       expect(survivor?.permissionLevelId).toBe(newLevel.id);
     });
 
+    test("lets an admin delete a grant on someone else's group", async ({
+      page,
+      browser,
+    }) => {
+      // the manager grants their own group access to their own drawer
+      const drawerId = await createDrawer(page, uniqueLabel("Managed Drawer"));
+      const groupId = await createDrawerGroup(page, uniqueLabel("Their Group"));
+      const levels = await getPermissionLevels(page);
+      const created = await createGrant(page, drawerId, groupId, levels[0].id);
+      expect(created.status()).toBe(201);
+      const managerGrant = (await created.json()).grant as Grant;
+
+      // the admin does not own that group, but reaches every drawer
+      const adminContext = await browser.newContext();
+      const adminPage = await adminContext.newPage();
+      await loginAdmin(adminPage);
+
+      const listed = (await listGrants(adminPage)).find(
+        (g) => g.id === managerGrant.id,
+      );
+      expect(listed?.group?.ownedByCurrentUser).toBe(false);
+
+      const removed = await adminPage.request.delete(
+        `${baseURL()}/drawerPermissions/grants/${managerGrant.id}`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(removed.status()).toBe(200);
+      await adminContext.close();
+
+      expect((await listGrants(page)).some((g) => g.id === managerGrant.id)).toBe(
+        false,
+      );
+    });
+
     // The flat /grants/{id} route makes every grant id addressable, so the
     // per-drawer check is the only thing scoping a manager to their own
     // drawers. The route gate passes anyone who manages any drawer at all.


### PR DESCRIPTION
- Adds a grants resource to `DrawerPermissions`: list, create, re-level, and delete the rules that link a drawer group to a drawer at a permission level, scoped to drawers the caller can manage.
- Restricts group updates to renames only, since a group's members belong to its type the type is fixed at creation.
- Fixes `Permissions::permissionLevels` to sort numerically instead of lexicographically (the level column is a string, so "10" sorted before "5").