### PR TITLE
add endpoints for collection management for elevator-ui

### DIFF
--- a/application/controllers/AdminCollections.php
+++ b/application/controllers/AdminCollections.php
@@ -86,7 +86,7 @@ class AdminCollections extends Instance_Controller {
   /**
    * POST /adminCollections/collections
    *
-   * Omitted S3 fields fall back to the instance defaults and
+   * Omitted or blank S3 fields fall back to the instance defaults and
    * showInBrowse defaults to true, matching the legacy new-collection
    * form's pre-filled values.
    */
@@ -96,6 +96,7 @@ class AdminCollections extends Instance_Controller {
     } catch (ValidationException $e) {
       return abort_json(['errors' => $e->getErrors()], 422);
     }
+    $validated = $this->dropBlankS3Overrides($validated);
 
     $parent = null;
     $parentId = (int) ($validated['parentId'] ?? 0);
@@ -131,7 +132,8 @@ class AdminCollections extends Instance_Controller {
    *
    * Title is always required. The other fields change only when
    * present in the body, so both verbs behave like PATCH. A parentId
-   * of 0 moves the collection to the top level.
+   * of 0 moves the collection to the top level, and a blank S3 field
+   * counts as absent.
    */
   private function updateCollection(int $collectionId): CI_Output {
     $collection = $this->findCollectionInInstance($collectionId);
@@ -144,6 +146,7 @@ class AdminCollections extends Instance_Controller {
     } catch (ValidationException $e) {
       return abort_json(['errors' => $e->getErrors()], 422);
     }
+    $validated = $this->dropBlankS3Overrides($validated);
 
     if (array_key_exists('parentId', $validated)) {
       $parentId = (int) $validated['parentId'];
@@ -224,6 +227,20 @@ class AdminCollections extends Instance_Controller {
     $this->clearUserCache();
 
     return render_json(['deleted' => $collectionId]);
+  }
+
+  /**
+   * A blank S3 override means "unset": create then falls back to the
+   * instance defaults, update keeps the stored value. Persisting ""
+   * would break asset storage.
+   */
+  private function dropBlankS3Overrides(array $validated): array {
+    foreach (['bucket', 'bucketRegion', 's3Key', 's3Secret'] as $field) {
+      if (($validated[$field] ?? null) === '') {
+        unset($validated[$field]);
+      }
+    }
+    return $validated;
   }
 
   /**

--- a/application/controllers/AdminCollections.php
+++ b/application/controllers/AdminCollections.php
@@ -10,9 +10,7 @@ use SimpleValidator as V;
  * pure json api for new ui
  *
  * Collection CRUD for the admin collections page. The legacy
- * CollectionManager keeps serving the old UI (plus share and bucket
- * creation) untouched, so the field assignment here deliberately
- * duplicates its save().
+ * CollectionManager keeps serving the old UI.
  */
 class AdminCollections extends Instance_Controller {
   private EntityManager $em;
@@ -229,9 +227,7 @@ class AdminCollections extends Instance_Controller {
   }
 
   /**
-   * Shared body schema for create and update. Title is always
-   * required, every other field is optional and update only touches
-   * the ones present.
+   * Shared body schema for create and update.
    */
   private function collectionSchema(): array {
     return [
@@ -249,8 +245,7 @@ class AdminCollections extends Instance_Controller {
 
   /**
    * The detail shape: the entity's list fields plus the admin-only
-   * settings, including the S3 secret (parity with the legacy edit
-   * form, which reveals it to instance admins).
+   * settings.
    */
   private function toCollectionDetail(Collection $collection): array {
     return array_merge($collection->jsonSerialize(), [
@@ -268,11 +263,7 @@ class AdminCollections extends Instance_Controller {
    *
    * Collection ids are global, so fetching one straight from the
    * repository would let an admin reach another instance's collection.
-   * Scanning the instance's collection list enforces membership, the
-   * same ownership pattern as AdminPermissions.
-   *
-   * @return ?Entity\Collection null when the instance has no such
-   *   collection
+   * Scanning the instance's collection list enforces membership.
    */
   private function findCollectionInInstance(int $collectionId): ?Collection {
     foreach ($this->instance->getCollections() as $candidate) {
@@ -284,31 +275,44 @@ class AdminCollections extends Instance_Controller {
   }
 
   /**
-   * A collection's parent may not be itself or one of its descendants,
-   * otherwise getFlattenedChildren() would recurse forever. Legacy only
-   * disabled these options client-side, so the API enforces it here.
-   *
-   * The walk is iterative with a visited set because legacy never
-   * guarded cycles, so pre-existing bad data must not hang the check.
+   * Check for cycles. Legacy disabled these options client-side,
+   * this API enforces it here.
    */
   private function wouldCreateParentCycle(Collection $collection, Collection $newParent): bool {
     if ($newParent->getId() === $collection->getId()) {
       return true;
     }
 
+    /** @var array<int, true> $visitedIds Keyed by collection id. */
     $visitedIds = [];
     $toVisit = [$collection];
+
+    // walk the graph of descendents, and check if $newParent
+    // is among them. If so, it would create a cycle.
     while (!empty($toVisit)) {
       $current = array_pop($toVisit);
+
+      // there are 3 possibilities with getChildren()
+      // 1. A plain tree: each collection has one parent, no repeats
+      // 2. A diamond (DAG): a shared descendent. it's possible to see
+      // the same child twice, but it's still acyclic
+      // 3. A cycle: corrupt data. Without a guard, you loop forever.
       foreach ($current->getChildren() as $child) {
         $childId = $child->getId();
+
+        // If we've seen this child, skip it.
+        // this guards against diamonds and cycles
         if (isset($visitedIds[$childId])) {
           continue;
         }
         $visitedIds[$childId] = true;
+
+        // check if this child is the newParent (a cycle)
         if ($childId === $newParent->getId()) {
           return true;
         }
+
+        // add the child to the stack of children to visit
         $toVisit[] = $child;
       }
     }

--- a/application/controllers/AdminCollections.php
+++ b/application/controllers/AdminCollections.php
@@ -1,0 +1,327 @@
+<?php
+if (! defined('BASEPATH')) exit('No direct script access allowed');
+
+use Doctrine\ORM\EntityManager;
+use Entity\Collection;
+use Entity\RecentCollection;
+use SimpleValidator as V;
+
+/**
+ * pure json api for new ui
+ *
+ * Collection CRUD for the admin collections page. The legacy
+ * CollectionManager keeps serving the old UI (plus share and bucket
+ * creation) untouched, so the field assignment here deliberately
+ * duplicates its save().
+ */
+class AdminCollections extends Instance_Controller {
+  private EntityManager $em;
+
+  public function __construct() {
+    parent::__construct();
+    $this->load->library('SimpleValidator');
+    $this->em = $this->doctrine->em;
+  }
+
+  /**
+   * REST entry point for /adminCollections/collections[/{id}].
+   */
+  public function collections($collectionId = null) {
+    $this->abortUnlessAdmin();
+
+    $method = $this->input->server('REQUEST_METHOD');
+
+    if ($collectionId !== null) {
+      $collectionId = filter_var($collectionId, FILTER_VALIDATE_INT);
+      if ($collectionId === false) {
+        return abort_json(['error' => 'Invalid ID'], 400);
+      }
+    }
+
+    $route = $collectionId === null
+      ? '/collections'
+      : '/collections/{id}';
+
+    $table = [
+      '/collections' => [
+        'GET' => fn() => $this->listCollections(),
+        'POST' => fn() => $this->createCollection(),
+      ],
+      '/collections/{id}' => [
+        'GET' => fn() => $this->getCollection($collectionId),
+        'PUT' => fn() => $this->updateCollection($collectionId),
+        'PATCH' => fn() => $this->updateCollection($collectionId),
+        'DELETE' => fn() => $this->deleteCollection($collectionId),
+      ],
+    ];
+
+    $handler = $table[$route][$method] ?? null;
+
+    if ($handler) {
+      return $handler();
+    }
+
+    return abort_json(['error' => 'Method Not Allowed'], 405);
+  }
+
+  /**
+   * GET /adminCollections/collections
+   */
+  private function listCollections(): CI_Output {
+    $collections = $this->instance->getCollections()->toArray();
+
+    return render_json(['collections' => array_values($collections)]);
+  }
+
+  /**
+   * GET /adminCollections/collections/{id}
+   */
+  private function getCollection(int $collectionId): CI_Output {
+    $collection = $this->findCollectionInInstance($collectionId);
+    if (!$collection) {
+      return abort_json(['error' => 'Collection not found'], 404);
+    }
+
+    return render_json(['collection' => $this->toCollectionDetail($collection)]);
+  }
+
+  /**
+   * POST /adminCollections/collections
+   *
+   * Omitted S3 fields fall back to the instance defaults and
+   * showInBrowse defaults to true, matching the legacy new-collection
+   * form's pre-filled values.
+   */
+  private function createCollection(): CI_Output {
+    try {
+      $validated = V::validate($this->requestBody(), $this->collectionSchema());
+    } catch (ValidationException $e) {
+      return abort_json(['errors' => $e->getErrors()], 422);
+    }
+
+    $parent = null;
+    $parentId = (int) ($validated['parentId'] ?? 0);
+    if ($parentId !== 0) {
+      $parent = $this->findCollectionInInstance($parentId);
+      if (!$parent) {
+        return abort_json(['error' => 'Parent collection not found'], 422);
+      }
+    }
+
+    $collection = new Collection();
+    $collection->addInstance($this->instance);
+    $collection->setTitle($validated['title']);
+    $collection->setParent($parent);
+    $collection->setShowInBrowse(
+      filter_var($validated['showInBrowse'] ?? 'true', FILTER_VALIDATE_BOOLEAN)
+    );
+    $collection->setCollectionDescription($validated['description'] ?? null);
+    $collection->setPreviewImage($validated['previewImageId'] ?? null);
+    $collection->setBucket($validated['bucket'] ?? $this->instance->getDefaultBucket());
+    $collection->setBucketRegion($validated['bucketRegion'] ?? $this->instance->getBucketRegion());
+    $collection->setS3Key($validated['s3Key'] ?? $this->instance->getAmazonS3Key());
+    $collection->setS3Secret($validated['s3Secret'] ?? $this->instance->getAmazonS3Secret());
+
+    $this->em->persist($collection);
+    $this->em->flush();
+
+    return render_json(['collection' => $this->toCollectionDetail($collection)], 201);
+  }
+
+  /**
+   * PUT|PATCH /adminCollections/collections/{id}
+   *
+   * Title is always required. The other fields change only when
+   * present in the body, so both verbs behave like PATCH. A parentId
+   * of 0 moves the collection to the top level.
+   */
+  private function updateCollection(int $collectionId): CI_Output {
+    $collection = $this->findCollectionInInstance($collectionId);
+    if (!$collection) {
+      return abort_json(['error' => 'Collection not found'], 404);
+    }
+
+    try {
+      $validated = V::validate($this->requestBody(), $this->collectionSchema());
+    } catch (ValidationException $e) {
+      return abort_json(['errors' => $e->getErrors()], 422);
+    }
+
+    if (array_key_exists('parentId', $validated)) {
+      $parentId = (int) $validated['parentId'];
+      if ($parentId === 0) {
+        $collection->setParent(null);
+      } else {
+        $parent = $this->findCollectionInInstance($parentId);
+        if (!$parent) {
+          return abort_json(['error' => 'Parent collection not found'], 422);
+        }
+        if ($this->wouldCreateParentCycle($collection, $parent)) {
+          return abort_json(
+            ['error' => 'Parent cannot be the collection itself or one of its descendants'],
+            422
+          );
+        }
+        $collection->setParent($parent);
+      }
+    }
+
+    $collection->setTitle($validated['title']);
+    if (array_key_exists('showInBrowse', $validated)) {
+      $collection->setShowInBrowse(
+        filter_var($validated['showInBrowse'], FILTER_VALIDATE_BOOLEAN)
+      );
+    }
+    if (array_key_exists('description', $validated)) {
+      $collection->setCollectionDescription($validated['description']);
+    }
+    if (array_key_exists('previewImageId', $validated)) {
+      $collection->setPreviewImage($validated['previewImageId']);
+    }
+    if (array_key_exists('bucket', $validated)) {
+      $collection->setBucket($validated['bucket']);
+    }
+    if (array_key_exists('bucketRegion', $validated)) {
+      $collection->setBucketRegion($validated['bucketRegion']);
+    }
+    if (array_key_exists('s3Key', $validated)) {
+      $collection->setS3Key($validated['s3Key']);
+    }
+    if (array_key_exists('s3Secret', $validated)) {
+      $collection->setS3Secret($validated['s3Secret']);
+    }
+
+    $this->em->flush();
+
+    return render_json(['collection' => $this->toCollectionDetail($collection)]);
+  }
+
+  /**
+   * DELETE /adminCollections/collections/{id}
+   *
+   * Legacy cascade parity: children move to the top level rather than
+   * deleting with their parent, and RecentCollection rows are purged.
+   * CollectionPermission grants cascade away at the ORM level.
+   */
+  private function deleteCollection(int $collectionId): CI_Output {
+    $collection = $this->findCollectionInInstance($collectionId);
+    if (!$collection) {
+      return abort_json(['error' => 'Collection not found'], 404);
+    }
+
+    foreach ($collection->getChildren() as $child) {
+      $child->setParent(null);
+    }
+
+    $recentCollections = $this->em
+      ->getRepository(RecentCollection::class)
+      ->findBy(['collection' => $collection]);
+    foreach ($recentCollections as $recentCollection) {
+      $this->em->remove($recentCollection);
+    }
+
+    $this->em->remove($collection);
+    $this->em->flush();
+
+    $this->clearUserCache();
+
+    return render_json(['deleted' => $collectionId]);
+  }
+
+  /**
+   * Shared body schema for create and update. Title is always
+   * required, every other field is optional and update only touches
+   * the ones present.
+   */
+  private function collectionSchema(): array {
+    return [
+      'title' => [V::required(), V::string()],
+      'parentId' => [V::integer()],
+      'showInBrowse' => [V::string()],
+      'description' => [V::string()],
+      'previewImageId' => [V::string()],
+      'bucket' => [V::string()],
+      'bucketRegion' => [V::string()],
+      's3Key' => [V::string()],
+      's3Secret' => [V::string()],
+    ];
+  }
+
+  /**
+   * The detail shape: the entity's list fields plus the admin-only
+   * settings, including the S3 secret (parity with the legacy edit
+   * form, which reveals it to instance admins).
+   */
+  private function toCollectionDetail(Collection $collection): array {
+    return array_merge($collection->jsonSerialize(), [
+      'description' => $collection->getCollectionDescription(),
+      'bucket' => $collection->getBucket(),
+      'bucketRegion' => $collection->getBucketRegion(),
+      's3Key' => $collection->getS3Key(),
+      's3Secret' => $collection->getS3Secret(),
+    ]);
+  }
+
+  /**
+   * Find the collection with `$collectionId` among this instance's own
+   * collections.
+   *
+   * Collection ids are global, so fetching one straight from the
+   * repository would let an admin reach another instance's collection.
+   * Scanning the instance's collection list enforces membership, the
+   * same ownership pattern as AdminPermissions.
+   *
+   * @return ?Entity\Collection null when the instance has no such
+   *   collection
+   */
+  private function findCollectionInInstance(int $collectionId): ?Collection {
+    foreach ($this->instance->getCollections() as $candidate) {
+      if ($candidate->getId() === $collectionId) {
+        return $candidate;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * A collection's parent may not be itself or one of its descendants,
+   * otherwise getFlattenedChildren() would recurse forever. Legacy only
+   * disabled these options client-side, so the API enforces it here.
+   *
+   * The walk is iterative with a visited set because legacy never
+   * guarded cycles, so pre-existing bad data must not hang the check.
+   */
+  private function wouldCreateParentCycle(Collection $collection, Collection $newParent): bool {
+    if ($newParent->getId() === $collection->getId()) {
+      return true;
+    }
+
+    $visitedIds = [];
+    $toVisit = [$collection];
+    while (!empty($toVisit)) {
+      $current = array_pop($toVisit);
+      foreach ($current->getChildren() as $child) {
+        $childId = $child->getId();
+        if (isset($visitedIds[$childId])) {
+          continue;
+        }
+        $visitedIds[$childId] = true;
+        if ($childId === $newParent->getId()) {
+          return true;
+        }
+        $toVisit[] = $child;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Clear cached user permissions after a delete so the cascaded
+   * grant removals take effect immediately.
+   */
+  private function clearUserCache(): void {
+    if ($this->config->item('enableCaching')) {
+      $this->userCache->clear();
+    }
+  }
+}

--- a/application/controllers/AdminCollections.php
+++ b/application/controllers/AdminCollections.php
@@ -304,14 +304,14 @@ class AdminCollections extends Instance_Controller {
     $visitedIds = [];
     $toVisit = [$collection];
 
-    // walk the graph of descendents, and check if $newParent
+    // walk the graph of descendants, and check if $newParent
     // is among them. If so, it would create a cycle.
     while (!empty($toVisit)) {
       $current = array_pop($toVisit);
 
       // there are 3 possibilities with getChildren()
       // 1. A plain tree: each collection has one parent, no repeats
-      // 2. A diamond (DAG): a shared descendent. it's possible to see
+      // 2. A diamond (DAG): a shared descendant. it's possible to see
       // the same child twice, but it's still acyclic
       // 3. A cycle: corrupt data. Without a guard, you loop forever.
       foreach ($current->getChildren() as $child) {

--- a/application/models/Entity/Collection.php
+++ b/application/models/Entity/Collection.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
  */
 #[ORM\Table(name: 'collections')]
 #[ORM\Entity]
-class Collection
+class Collection implements \JsonSerializable
 {
     /**
      * Elevator addition
@@ -624,5 +624,22 @@ class Collection
     public function getInstances()
     {
         return $this->instances;
+    }
+
+    /**
+     * The list shape for the new UI. Admin-only settings (S3 config,
+     * description) are added by AdminCollections::toCollectionDetail so
+     * a stray json_encode of a collection can't leak credentials.
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id'             => $this->id,
+            // legacy rows can have a null title, the UI contract says string
+            'title'          => $this->title ?? '',
+            'parentId'       => $this->parent?->getId(),
+            'showInBrowse'   => (bool) $this->showInBrowse,
+            'previewImageId' => $this->previewImage,
+        ];
     }
 }

--- a/tests/api/adminCollections.spec.ts
+++ b/tests/api/adminCollections.spec.ts
@@ -1,0 +1,441 @@
+import { test, expect, type APIResponse, type Page } from "@playwright/test";
+import { loginUser, createUser, refreshDatabase, baseURL } from "../helpers";
+
+// Endpoints under AdminCollections.php, the JSON collection CRUD for the
+// new admin UI. Every verb reads a form-encoded body and requires an
+// instance admin session.
+
+const collectionsURL = (): string =>
+  `${baseURL()}/adminCollections/collections`;
+
+// Collection::jsonSerialize(), the shape list items use.
+type CollectionListItem = {
+  id: number;
+  title: string;
+  parentId: number | null;
+  showInBrowse: boolean;
+  previewImageId: string | null;
+};
+
+// The detail shape adds the admin-only settings the list omits.
+type CollectionDetail = CollectionListItem & {
+  description: string | null;
+  bucket: string | null;
+  bucketRegion: string | null;
+  s3Key: string | null;
+  s3Secret: string | null;
+};
+
+async function loginAdmin(page: Page): Promise<void> {
+  await loginUser(page, "admin");
+}
+
+async function collectionFrom(res: APIResponse): Promise<CollectionDetail> {
+  return (await res.json()).collection as CollectionDetail;
+}
+
+async function createCollection(
+  page: Page,
+  form: Record<string, string>,
+): Promise<CollectionDetail> {
+  const res = await page.request.post(collectionsURL(), { form });
+  expect(res.status()).toBe(201);
+  return collectionFrom(res);
+}
+
+async function getCollection(
+  page: Page,
+  collectionId: number,
+): Promise<CollectionDetail> {
+  const res = await page.request.get(`${collectionsURL()}/${collectionId}`, {
+    headers: { Accept: "application/json" },
+  });
+  expect(res.status()).toBe(200);
+  return collectionFrom(res);
+}
+
+test.describe("adminCollections", () => {
+  test.describe("unauthenticated", () => {
+    const requests = [
+      { method: "GET", path: "/adminCollections/collections" },
+      { method: "POST", path: "/adminCollections/collections" },
+      { method: "GET", path: "/adminCollections/collections/1" },
+      { method: "PUT", path: "/adminCollections/collections/1" },
+      { method: "DELETE", path: "/adminCollections/collections/1" },
+    ] as const;
+
+    for (const { method, path } of requests) {
+      test(`${method} ${path} returns 401`, async ({ page }) => {
+        const res = await page.request.fetch(`${baseURL()}${path}`, {
+          method,
+          headers: { Accept: "application/json" },
+        });
+        expect(res.status()).toBe(401);
+      });
+    }
+  });
+
+  test.describe("as a non-admin user", () => {
+    const NON_ADMIN = {
+      username: "e2e-not-an-admin",
+      password: "e2e-not-an-admin",
+    };
+
+    // reset-test-db.sh never truncates users, so find-or-create survives
+    // previous runs
+    test.beforeAll(async ({ browser }) => {
+      const context = await browser.newContext();
+      const page = await context.newPage();
+      await loginAdmin(page);
+      await createUser(page, NON_ADMIN.username, NON_ADMIN.password);
+      await context.close();
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await loginUser(page, NON_ADMIN.username, NON_ADMIN.password);
+    });
+
+    test("GET collections returns 403", async ({ page }) => {
+      const res = await page.request.get(collectionsURL(), {
+        headers: { Accept: "application/json" },
+      });
+      expect(res.status()).toBe(403);
+    });
+
+    test("POST collections returns 403", async ({ page }) => {
+      const res = await page.request.post(collectionsURL(), {
+        form: { title: "Should Not Exist" },
+      });
+      expect(res.status()).toBe(403);
+    });
+  });
+
+  test.describe("as an admin", () => {
+    test.beforeAll(() => {
+      refreshDatabase();
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await loginAdmin(page);
+    });
+
+    test.afterEach(() => {
+      refreshDatabase();
+    });
+
+    test("creates a collection with defaults from a title alone", async ({
+      page,
+    }) => {
+      const collection = await createCollection(page, {
+        title: "Bare Minimum",
+      });
+
+      expect(collection.id).toBeGreaterThan(0);
+      expect(collection.title).toBe("Bare Minimum");
+      expect(collection.parentId).toBeNull();
+      expect(collection.showInBrowse).toBe(true);
+      expect(collection.description).toBeNull();
+    });
+
+    test("stores showInBrowse false from the string form value", async ({
+      page,
+    }) => {
+      const collection = await createCollection(page, {
+        title: "Hidden From Browse",
+        showInBrowse: "false",
+      });
+      expect(collection.showInBrowse).toBe(false);
+    });
+
+    test("stores explicit S3 overrides", async ({ page }) => {
+      const collection = await createCollection(page, {
+        title: "Custom S3",
+        bucket: "custom-bucket",
+        bucketRegion: "us-test-1",
+        s3Key: "custom-key",
+        s3Secret: "custom-secret",
+      });
+
+      expect(collection.bucket).toBe("custom-bucket");
+      expect(collection.bucketRegion).toBe("us-test-1");
+      expect(collection.s3Key).toBe("custom-key");
+      expect(collection.s3Secret).toBe("custom-secret");
+    });
+
+    test("blank S3 fields fall back to instance defaults like omitted ones", async ({
+      page,
+    }) => {
+      const omitted = await createCollection(page, { title: "Omitted S3" });
+      const blank = await createCollection(page, {
+        title: "Blank S3",
+        bucket: "",
+        bucketRegion: "",
+        s3Key: "",
+        s3Secret: "",
+      });
+
+      expect(blank.bucket).toBe(omitted.bucket);
+      expect(blank.bucketRegion).toBe(omitted.bucketRegion);
+      expect(blank.s3Key).toBe(omitted.s3Key);
+      expect(blank.s3Secret).toBe(omitted.s3Secret);
+    });
+
+    test("lists collections without S3 settings", async ({ page }) => {
+      const created = await createCollection(page, {
+        title: "Listed Collection",
+        s3Key: "leaky-key",
+        s3Secret: "leaky-secret",
+      });
+
+      const res = await page.request.get(collectionsURL(), {
+        headers: { Accept: "application/json" },
+      });
+      expect(res.status()).toBe(200);
+      const { collections } = (await res.json()) as {
+        collections: CollectionListItem[];
+      };
+
+      const item = collections.find(
+        (candidate) => candidate.id === created.id,
+      );
+      expect(item).toBeDefined();
+      expect(item?.title).toBe("Listed Collection");
+      expect(item?.showInBrowse).toBe(true);
+      expect(item).not.toHaveProperty("s3Key");
+      expect(item).not.toHaveProperty("s3Secret");
+      expect(item).not.toHaveProperty("bucket");
+    });
+
+    test("returns the detail shape for a single collection", async ({
+      page,
+    }) => {
+      const created = await createCollection(page, {
+        title: "Detailed",
+        description: "A described collection",
+      });
+
+      const collection = await getCollection(page, created.id);
+      expect(collection.id).toBe(created.id);
+      expect(collection.title).toBe("Detailed");
+      expect(collection.description).toBe("A described collection");
+    });
+
+    test("rejects a missing title with 422 on create and update", async ({
+      page,
+    }) => {
+      const create = await page.request.post(collectionsURL(), {
+        form: { description: "No title here" },
+      });
+      expect(create.status()).toBe(422);
+      expect((await create.json()).errors).toHaveProperty("title");
+
+      const existing = await createCollection(page, { title: "Needs Title" });
+      const update = await page.request.put(
+        `${collectionsURL()}/${existing.id}`,
+        { form: { description: "still no title" } },
+      );
+      expect(update.status()).toBe(422);
+      expect((await update.json()).errors).toHaveProperty("title");
+    });
+
+    test("an unknown parentId returns 422 on create and update", async ({
+      page,
+    }) => {
+      const create = await page.request.post(collectionsURL(), {
+        form: { title: "Orphan", parentId: "99999999" },
+      });
+      expect(create.status()).toBe(422);
+
+      const existing = await createCollection(page, { title: "Movable" });
+      const update = await page.request.put(
+        `${collectionsURL()}/${existing.id}`,
+        { form: { title: "Movable", parentId: "99999999" } },
+      );
+      expect(update.status()).toBe(422);
+    });
+
+    test("creates a child under a parent and parentId 0 moves it to the top", async ({
+      page,
+    }) => {
+      const parent = await createCollection(page, { title: "Parent" });
+      const child = await createCollection(page, {
+        title: "Child",
+        parentId: String(parent.id),
+      });
+      expect(child.parentId).toBe(parent.id);
+
+      const res = await page.request.put(`${collectionsURL()}/${child.id}`, {
+        form: { title: "Child", parentId: "0" },
+      });
+      expect(res.status()).toBe(200);
+      expect((await collectionFrom(res)).parentId).toBeNull();
+    });
+
+    test("updates only the fields present in the body", async ({ page }) => {
+      const created = await createCollection(page, {
+        title: "Original Title",
+        description: "Original description",
+        bucket: "original-bucket",
+      });
+
+      const res = await page.request.put(`${collectionsURL()}/${created.id}`, {
+        form: { title: "New Title" },
+      });
+      expect(res.status()).toBe(200);
+      const updated = await collectionFrom(res);
+
+      expect(updated.title).toBe("New Title");
+      expect(updated.description).toBe("Original description");
+      expect(updated.bucket).toBe("original-bucket");
+    });
+
+    test("PATCH updates like PUT", async ({ page }) => {
+      const created = await createCollection(page, { title: "Patch Me" });
+
+      const res = await page.request.patch(
+        `${collectionsURL()}/${created.id}`,
+        { form: { title: "Patched", showInBrowse: "false" } },
+      );
+      expect(res.status()).toBe(200);
+      const updated = await collectionFrom(res);
+      expect(updated.title).toBe("Patched");
+      expect(updated.showInBrowse).toBe(false);
+    });
+
+    test("a blank S3 field keeps the stored value on update", async ({
+      page,
+    }) => {
+      const created = await createCollection(page, {
+        title: "Keeps S3",
+        bucket: "original-bucket",
+        s3Key: "original-key",
+      });
+
+      const blanked = await page.request.put(
+        `${collectionsURL()}/${created.id}`,
+        { form: { title: "Keeps S3", bucket: "", s3Key: "" } },
+      );
+      expect(blanked.status()).toBe(200);
+      const afterBlank = await collectionFrom(blanked);
+      expect(afterBlank.bucket).toBe("original-bucket");
+      expect(afterBlank.s3Key).toBe("original-key");
+
+      const replaced = await page.request.put(
+        `${collectionsURL()}/${created.id}`,
+        { form: { title: "Keeps S3", bucket: "replacement-bucket" } },
+      );
+      expect(replaced.status()).toBe(200);
+      expect((await collectionFrom(replaced)).bucket).toBe(
+        "replacement-bucket",
+      );
+    });
+
+    test("clears the description with an empty string", async ({ page }) => {
+      const created = await createCollection(page, {
+        title: "Described",
+        description: "Something",
+      });
+
+      const res = await page.request.put(`${collectionsURL()}/${created.id}`, {
+        form: { title: "Described", description: "" },
+      });
+      expect(res.status()).toBe(200);
+      expect((await collectionFrom(res)).description).toBe("");
+    });
+
+    test("rejects a parent that is the collection itself or a descendant", async ({
+      page,
+    }) => {
+      const top = await createCollection(page, { title: "Top" });
+      const middle = await createCollection(page, {
+        title: "Middle",
+        parentId: String(top.id),
+      });
+      const bottom = await createCollection(page, {
+        title: "Bottom",
+        parentId: String(middle.id),
+      });
+
+      const ontoItself = await page.request.put(
+        `${collectionsURL()}/${top.id}`,
+        { form: { title: "Top", parentId: String(top.id) } },
+      );
+      expect(ontoItself.status()).toBe(422);
+
+      const ontoGrandchild = await page.request.put(
+        `${collectionsURL()}/${top.id}`,
+        { form: { title: "Top", parentId: String(bottom.id) } },
+      );
+      expect(ontoGrandchild.status()).toBe(422);
+
+      // moving up the chain is not a cycle, so it still works
+      const ontoGrandparent = await page.request.put(
+        `${collectionsURL()}/${bottom.id}`,
+        { form: { title: "Bottom", parentId: String(top.id) } },
+      );
+      expect(ontoGrandparent.status()).toBe(200);
+      expect((await collectionFrom(ontoGrandparent)).parentId).toBe(top.id);
+    });
+
+    test("deletes a collection and moves its children to the top level", async ({
+      page,
+    }) => {
+      const parent = await createCollection(page, { title: "Doomed Parent" });
+      const child = await createCollection(page, {
+        title: "Surviving Child",
+        parentId: String(parent.id),
+      });
+
+      const res = await page.request.delete(
+        `${collectionsURL()}/${parent.id}`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(res.status()).toBe(200);
+      expect((await res.json()).deleted).toBe(parent.id);
+
+      const gone = await page.request.get(`${collectionsURL()}/${parent.id}`, {
+        headers: { Accept: "application/json" },
+      });
+      expect(gone.status()).toBe(404);
+
+      const survivor = await getCollection(page, child.id);
+      expect(survivor.parentId).toBeNull();
+    });
+
+    test("fetching, updating, or deleting a missing collection returns 404", async ({
+      page,
+    }) => {
+      const missing = `${collectionsURL()}/99999999`;
+
+      const get = await page.request.get(missing, {
+        headers: { Accept: "application/json" },
+      });
+      expect(get.status()).toBe(404);
+
+      const put = await page.request.put(missing, {
+        form: { title: "Ghost" },
+      });
+      expect(put.status()).toBe(404);
+
+      const del = await page.request.delete(missing, {
+        headers: { Accept: "application/json" },
+      });
+      expect(del.status()).toBe(404);
+    });
+
+    test("returns 400 for a non-numeric id", async ({ page }) => {
+      const res = await page.request.get(
+        `${collectionsURL()}/not-a-number`,
+        { headers: { Accept: "application/json" } },
+      );
+      expect(res.status()).toBe(400);
+    });
+
+    test("DELETE on the list route returns 405", async ({ page }) => {
+      const res = await page.request.delete(collectionsURL(), {
+        headers: { Accept: "application/json" },
+      });
+      expect(res.status()).toBe(405);
+    });
+  });
+});


### PR DESCRIPTION
- Adds `/adminCollections/collections` CRUD endpoints for the new elevator-ui admin collections page, following the `AdminPermissions` conventions.
- Adds a parent-cycle guard on update to prevent accidental infinite loops when flattening nested collections.
- legacy `CollectionManager` is untouched and keeps serving the old UI, share, and bucket creation.