### PR TITLE
Add showChildCollections instance setting (additionalSettings jsonb)

### DIFF
--- a/application/controllers/Home.php
+++ b/application/controllers/Home.php
@@ -268,6 +268,8 @@ class Home extends Instance_Controller {
 
 		$headerData['useVoyagerViewer'] = $this->instance->getUseVoyagerViewer() ?? false;
 
+		$headerData['showChildCollections'] = $this->instance->getAdditionalSettings()['showChildCollections'];
+
 		$headerData['theming'] = [
 			'availableThemes' => $this->instance->getAvailableThemes(),
 			'enabled' => $this->instance->getEnableThemes(),

--- a/application/controllers/Instances.php
+++ b/application/controllers/Instances.php
@@ -54,6 +54,7 @@ class Instances extends Instance_Controller
 			'enableTheming' => $instance->getEnableThemes(),
 			'defaultTheme' => $instance->getDefaultTheme(),
 			'availableThemes' => $instance->getAvailableThemes(),
+			'showChildCollections' => $instance->getAdditionalSettings()['showChildCollections'],
 			'customHomeRedirect' => $instance->getCustomHomeRedirect(),
 			'maximumMoreLikeThis' => $instance->getMaximumMoreLikeThis(),
 			'defaultTextTruncationHeight' => $instance->getDefaultTextTruncationHeight(),
@@ -153,6 +154,9 @@ class Instances extends Instance_Controller
 		$instance->setEnableThemes($this->input->post('enableTheming'));
 		$instance->setDefaultTheme($this->input->post('defaultTheme'));
 		$instance->setAvailableThemes($this->input->post('availableThemes'));
+		$instance->setAdditionalSettings([
+			'showChildCollections' => $this->input->post('showChildCollections') ? true : false,
+		]);
 		$instance->setCustomHomeRedirect($this->input->post('customHomeRedirect'));
 		$instance->setMaximumMoreLikeThis($this->input->post('maximumMoreLikeThis'));
 		$instance->setDefaultTextTruncationHeight($this->input->post('defaultTextTruncationHeight'));

--- a/application/models/Entity/Instance.php
+++ b/application/models/Entity/Instance.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity]
 class Instance
 {
-    /** 
+    /**
      * Elevator
      * @var array|null
      */
@@ -262,6 +262,14 @@ class Instance
      */
     #[ORM\Column(name: 'availableThemes', type: 'json', nullable: true, options: ['jsonb' => true])]
     private $availableThemes;
+
+    /**
+     * Instance settings for the new ui in json blob
+     * This replaces the old setting-per-column approach.
+     * @var array<string, mixed>|null
+     */
+    #[ORM\Column(name: 'additionalSettings', type: 'json', nullable: true, options: ['jsonb' => true])]
+    private $additionalSettings = [];
 
     /**
      * @var int
@@ -1297,6 +1305,33 @@ class Instance
     public function getAvailableThemes()
     {
         return $this->availableThemes;
+    }
+
+    /**
+     * Set additionalSettings.
+     *
+     * @param array<string, mixed>|null $additionalSettings
+     */
+    public function setAdditionalSettings(?array $additionalSettings = null): self
+    {
+        $this->additionalSettings = $additionalSettings ?? [];
+
+        return $this;
+    }
+
+    /**
+     * Get all additional settings, filling in defaults for any keys the
+     * stored blob is missing.
+     *
+     * @return array<string, mixed>
+     */
+    public function getAdditionalSettings(): array
+    {
+        $defaults = [
+            'showChildCollections' => true,
+        ];
+
+        return array_merge($defaults, $this->additionalSettings ?? []);
     }
 
     /**


### PR DESCRIPTION
- Adds an instance-wide `showChildCollections` setting (default on) that controls the browse page's sub-collections panel.
- Introduces an `additionalSettings` jsonb column on the Instance entity as the home for low-stakes instance settings, so we stop widening the `instances` table one flat column at a time.
- Includes the flag in both the settings editor payload and the instance nav payload.

Companion to https://github.com/UMN-LATIS/elevator-ui/pull/593