### PR TITLE
Serve `showThumbnailDescription` instance setting

### DIFF
--- a/application/controllers/Home.php
+++ b/application/controllers/Home.php
@@ -168,6 +168,8 @@ class Home extends Instance_Controller {
 		$headerData["instanceShowTemplateInSearchResults"] = $this->instance->getShowTemplateInSearchResults();
 		$headerData["featuredAssetId"] = $this->instance->getFeaturedAsset();
 		$headerData["featuredAssetText"] = $this->instance->getFeaturedAssetText();
+    $headerData['showChildCollections'] = $this->instance->getShowChildCollections();
+    $headerData['showThumbnailDescription'] = $this->instance->getShowThumbnailDescription();
 
 		// load prefs for a logged in user
 		if ($this->user_model->userLoaded && !$this->user_model->assetOverride) {

--- a/application/controllers/Home.php
+++ b/application/controllers/Home.php
@@ -168,8 +168,7 @@ class Home extends Instance_Controller {
 		$headerData["instanceShowTemplateInSearchResults"] = $this->instance->getShowTemplateInSearchResults();
 		$headerData["featuredAssetId"] = $this->instance->getFeaturedAsset();
 		$headerData["featuredAssetText"] = $this->instance->getFeaturedAssetText();
-    $headerData['showChildCollections'] = $this->instance->getShowChildCollections();
-    $headerData['showThumbnailDescription'] = $this->instance->getShowThumbnailDescription();
+		$headerData['showThumbnailDescription'] = $this->instance->getShowThumbnailDescription();
 
 		// load prefs for a logged in user
 		if ($this->user_model->userLoaded && !$this->user_model->assetOverride) {
@@ -270,7 +269,7 @@ class Home extends Instance_Controller {
 
 		$headerData['useVoyagerViewer'] = $this->instance->getUseVoyagerViewer() ?? false;
 
-		$headerData['showChildCollections'] = $this->instance->getAdditionalSettings()['showChildCollections'];
+		$headerData['showChildCollections'] = $this->instance->getShowChildCollections();
 
 		$headerData['theming'] = [
 			'availableThemes' => $this->instance->getAvailableThemes(),

--- a/application/controllers/Instances.php
+++ b/application/controllers/Instances.php
@@ -55,7 +55,7 @@ class Instances extends Instance_Controller
 			'defaultTheme' => $instance->getDefaultTheme(),
 			'availableThemes' => $instance->getAvailableThemes(),
 			'showChildCollections' => $instance->getShowChildCollections(),
-      'showThumbnailDescription' => $instance->getShowThumbnailDescription(),
+			'showThumbnailDescription' => $instance->getShowThumbnailDescription(),
 			'customHomeRedirect' => $instance->getCustomHomeRedirect(),
 			'maximumMoreLikeThis' => $instance->getMaximumMoreLikeThis(),
 			'defaultTextTruncationHeight' => $instance->getDefaultTextTruncationHeight(),

--- a/application/controllers/Instances.php
+++ b/application/controllers/Instances.php
@@ -54,7 +54,8 @@ class Instances extends Instance_Controller
 			'enableTheming' => $instance->getEnableThemes(),
 			'defaultTheme' => $instance->getDefaultTheme(),
 			'availableThemes' => $instance->getAvailableThemes(),
-			'showChildCollections' => $instance->getAdditionalSettings()['showChildCollections'],
+			'showChildCollections' => $instance->getShowChildCollections(),
+      'showThumbnailDescription' => $instance->getShowThumbnailDescription(),
 			'customHomeRedirect' => $instance->getCustomHomeRedirect(),
 			'maximumMoreLikeThis' => $instance->getMaximumMoreLikeThis(),
 			'defaultTextTruncationHeight' => $instance->getDefaultTextTruncationHeight(),
@@ -156,6 +157,7 @@ class Instances extends Instance_Controller
 		$instance->setAvailableThemes($this->input->post('availableThemes'));
 		$instance->setAdditionalSettings([
 			'showChildCollections' => $this->input->post('showChildCollections') ? true : false,
+      'showThumbnailDescription' => $this->input->post('showThumbnailDescription') ? true : false
 		]);
 		$instance->setCustomHomeRedirect($this->input->post('customHomeRedirect'));
 		$instance->setMaximumMoreLikeThis($this->input->post('maximumMoreLikeThis'));
@@ -168,7 +170,7 @@ class Instances extends Instance_Controller
 		if($instance->getUseHeaderLogo()) {
 			if (! $this->upload->do_upload('customHeaderImage')) {
 				$error = array('error' => $this->upload->display_errors());
-			// var_dump($error); // TODO: draw this in a view 
+			// var_dump($error); // TODO: draw this in a view
 			// return;
 			}
 			else {
@@ -180,8 +182,8 @@ class Instances extends Instance_Controller
 			}
 		}
 
-		
-		
+
+
 
 
 		if($instance->getUseCustomHeader()) {
@@ -603,8 +605,8 @@ class Instances extends Instance_Controller
 			}
 
 			$result = $s3Client->putBucketVersioning([
-			    'Bucket' => $bucketName, 
-			    'VersioningConfiguration' => [ 
+			    'Bucket' => $bucketName,
+			    'VersioningConfiguration' => [
 			        'MFADelete' => 'Disabled',
 			        'Status' => 'Enabled',
 			    ],
@@ -639,7 +641,7 @@ class Instances extends Instance_Controller
     				],
 				]);
 			}
-			
+
 			$result = $s3Client->DeletePublicAccessBlock([
 				'Bucket'=>$bucketName
 			]);
@@ -704,7 +706,7 @@ class Instances extends Instance_Controller
 				}'
 			]);
 
-			
+
 
 
 			$newUser = "elevator-bucket_user" . $s3InstanceName;

--- a/application/controllers/Instances.php
+++ b/application/controllers/Instances.php
@@ -155,10 +155,8 @@ class Instances extends Instance_Controller
 		$instance->setEnableThemes($this->input->post('enableTheming'));
 		$instance->setDefaultTheme($this->input->post('defaultTheme'));
 		$instance->setAvailableThemes($this->input->post('availableThemes'));
-		$instance->setAdditionalSettings([
-			'showChildCollections' => $this->input->post('showChildCollections') ? true : false,
-      'showThumbnailDescription' => $this->input->post('showThumbnailDescription') ? true : false
-		]);
+		$instance->setShowChildCollections($this->input->post('showChildCollections') ? true : false);
+		$instance->setShowThumbnailDescription($this->input->post('showThumbnailDescription') ? true : false);
 		$instance->setCustomHomeRedirect($this->input->post('customHomeRedirect'));
 		$instance->setMaximumMoreLikeThis($this->input->post('maximumMoreLikeThis'));
 		$instance->setDefaultTextTruncationHeight($this->input->post('defaultTextTruncationHeight'));

--- a/application/models/Entity/Instance.php
+++ b/application/models/Entity/Instance.php
@@ -1308,18 +1308,6 @@ class Instance
     }
 
     /**
-     * Set additionalSettings.
-     *
-     * @param array<string, mixed>|null $additionalSettings
-     */
-    public function setAdditionalSettings(?array $additionalSettings = null): self
-    {
-        $this->additionalSettings = $additionalSettings ?? [];
-
-        return $this;
-    }
-
-    /**
      * Get all additional settings, filling in defaults for any keys the
      * stored blob is missing.
      *
@@ -1344,11 +1332,37 @@ class Instance
     }
 
     /**
+     * Write showChildCollections into the stored blob, preserving sibling keys.
+     */
+    public function setShowChildCollections(bool $value): self
+    {
+        $this->additionalSettings = array_merge(
+            $this->additionalSettings ?? [],
+            ['showChildCollections' => $value]
+        );
+
+        return $this;
+    }
+
+    /**
      * Whether the description text appears below an asset's thumbnail.
      */
     public function getShowThumbnailDescription(): bool
     {
         return (bool) $this->getAdditionalSettings()['showThumbnailDescription'];
+    }
+
+    /**
+     * Write showThumbnailDescription into the stored blob, preserving sibling keys.
+     */
+    public function setShowThumbnailDescription(bool $value): self
+    {
+        $this->additionalSettings = array_merge(
+            $this->additionalSettings ?? [],
+            ['showThumbnailDescription' => $value]
+        );
+
+        return $this;
     }
 
     /**

--- a/application/models/Entity/Instance.php
+++ b/application/models/Entity/Instance.php
@@ -1329,9 +1329,26 @@ class Instance
     {
         $defaults = [
             'showChildCollections' => true,
+            'showThumbnailDescription' => false,
         ];
 
         return array_merge($defaults, $this->additionalSettings ?? []);
+    }
+
+    /**
+     * Whether the collection page lists a collection's child collections.
+     */
+    public function getShowChildCollections(): bool
+    {
+        return (bool) $this->getAdditionalSettings()['showChildCollections'];
+    }
+
+    /**
+     * Whether the description text appears below an asset's thumbnail.
+     */
+    public function getShowThumbnailDescription(): bool
+    {
+        return (bool) $this->getAdditionalSettings()['showThumbnailDescription'];
     }
 
     /**


### PR DESCRIPTION
- Companion API PR for [UMN-LATIS/elevator-ui#592](https://github.com/UMN-LATIS/elevator-ui/issues/592) (configurable thumbnail descriptions)
- Adds `showThumbnailDescription` (default **off**) to the `additionalSettings` jsonb blob, served in both the `instanceNav` payload  and the admin instance settings response.
- Reads and writes the blob through typed accessors on `Instance` (`getShowThumbnailDescription()` / `setShowThumbnailDescription()`, and the same for `showChildCollections`) instead of reaching into the array by string key.
- No database migration: `additionalSettings` is an existing jsonb column, so a new key is schema-less.
