### PR TITLE
fixes for recursive thumb discovery

### DIFF
--- a/application/models/Asset_model.php
+++ b/application/models/Asset_model.php
@@ -284,7 +284,7 @@ class Asset_model extends CI_Model {
 	 * complain too much.)
 	 * @return [type] [description]
 	 */
-	public function getPrimaryFilehandler($tryCache = true, &$parentArray = array()) {
+	public function getPrimaryFilehandler($tryCache = true, &$parentArray = array(), $depth = 0) {
 		$fileHandler = NULL;
 
 		if($tryCache && $this->assetObject->getAssetCache() && ($this->useStaleCaches || !$this->assetObject->getAssetCache()->getNeedsRebuild())) {
@@ -302,33 +302,35 @@ class Asset_model extends CI_Model {
 			if(!$uploadContents = $this->findPrimaryWithinAsset($this, "Upload")) {
 				// no first tier primary, try nested - first see if the primary related has an image.
 
-				$relatedArray = $this->getAllWithinAsset("Related_asset", $this);
-				foreach($relatedArray as $asset) {
-					$primaries = array_column($asset->fieldContentsArray, "isPrimary");
-					$noPrimaries = !in_array(true, $primaries);
-					// if this related asset has the ignoreForDigitalAsset flag marked as true, we don't even consider it.
-					if(isset($asset->ignoreForDigitalAsset) && $asset->ignoreForDigitalAsset == true) {
-						continue;
-					}
-					
-					foreach($asset->fieldContentsArray as $fieldContents) {
+				if($depth < 2) {
+					$relatedArray = $this->getAllWithinAsset("Related_asset", $this);
+					foreach($relatedArray as $asset) {
+						$primaries = array_column($asset->fieldContentsArray, "isPrimary");
+						$noPrimaries = !in_array(true, $primaries);
+						// if this related asset has the ignoreForDigitalAsset flag marked as true, we don't even consider it.
+						if(isset($asset->ignoreForDigitalAsset) && $asset->ignoreForDigitalAsset == true) {
+							continue;
+						}
 						
-						if((!$asset->getAllowMultiple() || ($fieldContents->isPrimary || $noPrimaries) || count($asset->fieldContentsArray)==1) && !in_array($fieldContents->getRelatedObjectId(), $parentArray)) {
-							try {
-								$fileHandler = $fieldContents->getPrimaryFilehandler($parentArray);
-							}
-							catch (Exception $e) {
+						foreach($asset->fieldContentsArray as $fieldContents) {
+							
+							if((!$asset->getAllowMultiple() || ($fieldContents->isPrimary || $noPrimaries) || count($asset->fieldContentsArray)==1) && !in_array($fieldContents->getRelatedObjectId(), $parentArray)) {
+								try {
+									$fileHandler = $fieldContents->getPrimaryFilehandler($parentArray, $depth + 1);
+								}
+								catch (Exception $e) {
 
-							}
+								}
 
-							if($fileHandler) {
-								$foundPrimary = true;
-								break;
+								if($fileHandler) {
+									$foundPrimary = true;
+									break;
+								}
 							}
 						}
-					}
-					if($foundPrimary) {
-						break;
+						if($foundPrimary) {
+							break;
+						}
 					}
 				}
 

--- a/application/models/widget_contents/Related_asset_contents.php
+++ b/application/models/widget_contents/Related_asset_contents.php
@@ -94,7 +94,7 @@ class Related_asset_contents extends Widget_contents_base {
 		return false;
 	}
 
-	public function getPrimaryFileHandler(&$parentArray = array()) {
+	public function getPrimaryFileHandler(&$parentArray = array(), $depth = 0) {
 		if(!$this->cachedPrimaryHandler && $assetCache = $this->parentObject->assetObject->getAssetCache()) {
 			if($this->parentObject->useStaleCaches || !$assetCache->getNeedsRebuild()) {
 				$relatedAssetCache = $assetCache->getRelatedAssetCache();
@@ -122,7 +122,7 @@ class Related_asset_contents extends Widget_contents_base {
 					
 					$parentArray[] = $this->getRelatedObjectId();
 
-					$fileHandler = $relatedAsset->getPrimaryFilehandler(true, $parentArray);
+					$fileHandler = $relatedAsset->getPrimaryFilehandler(true, $parentArray, $depth);
 				}
 				else {
 					throw new Exception('Primary File Handler Not Found');


### PR DESCRIPTION
This deals with a bug that would cause cache building to hang if you had a very large graph of related records, none of which had a digital attachment. The cache would just keep walking through that graph looking for something to use as a thumbnail, until it ran out of memory. I think this is the right fix (mirroring our existing structure) but would love a second set of eyes