### PR TITLE
Save and return any client-minted widget content uuids

### DIFF
--- a/application/models/widget_contents/Date_contents.php
+++ b/application/models/widget_contents/Date_contents.php
@@ -18,7 +18,7 @@ class Date_contents extends Widget_contents_base {
 	 * @return [type] [description]
 	 */
 	public function getAsArray($serializeNestedObjects=false) {
-		return ["label"=>$this->label, "start"=>["text"=>$this->start["text"], "numeric"=>$this->start["numeric"]], "end"=>["text"=>$this->end["text"], "numeric"=>$this->end["numeric"]],"isPrimary"=>$this->isPrimary];
+		return ["label"=>$this->label, "start"=>["text"=>$this->start["text"], "numeric"=>$this->start["numeric"]], "end"=>["text"=>$this->end["text"], "numeric"=>$this->end["numeric"]],"isPrimary"=>$this->isPrimary, "uuid"=>$this->uuid];
 	}
 
 	public function getAsText($serializeNestedObjects=false) {

--- a/application/models/widget_contents/Location_contents.php
+++ b/application/models/widget_contents/Location_contents.php
@@ -19,7 +19,7 @@ class Location_contents extends Widget_contents_base {
 	 */
 	public function getAsArray($serializeNestedObjects=false) {
 
-		return ["locationLabel"=>$this->locationLabel, "address"=>$this->address, "loc"=>array("type"=>"Point","coordinates"=>[(float)$this->longitude,(float)$this->latitude]), "isPrimary"=>$this->isPrimary];
+		return ["locationLabel"=>$this->locationLabel, "address"=>$this->address, "loc"=>array("type"=>"Point","coordinates"=>[(float)$this->longitude,(float)$this->latitude]), "isPrimary"=>$this->isPrimary, "uuid"=>$this->uuid];
 	}
 
 	public function getAsText($serializeNestedObjects=false) {

--- a/application/models/widget_contents/Related_asset_contents.php
+++ b/application/models/widget_contents/Related_asset_contents.php
@@ -27,7 +27,7 @@ class Related_asset_contents extends Widget_contents_base {
 
 
 	public function getAsArray($nestedObjectDepth=0) {
-		return ["targetAssetId"=>$this->targetAssetId, "label"=>$this->label, "isPrimary"=>$this->isPrimary];
+		return ["targetAssetId"=>$this->targetAssetId, "label"=>$this->label, "isPrimary"=>$this->isPrimary, "uuid"=>$this->uuid];
 	}
 
 	public function getRelatedObjectId() {

--- a/application/models/widget_contents/Tags_contents.php
+++ b/application/models/widget_contents/Tags_contents.php
@@ -13,7 +13,7 @@ class Tags_contents extends Widget_contents_base {
 
 
 	public function getAsArray($serializeNestedObjects=false) {
-		return ["tags"=>$this->tags, "isPrimary"=>$this->isPrimary];
+		return ["tags"=>$this->tags, "isPrimary"=>$this->isPrimary, "uuid"=>$this->uuid];
 	}
 
 	public function getAsText($serializeNestedObjects=false) {

--- a/application/models/widget_contents/Upload_contents.php
+++ b/application/models/widget_contents/Upload_contents.php
@@ -48,7 +48,7 @@ class Upload_contents extends Widget_contents_base {
 			}
 
 
-			return array_merge($dateData, ["fileId"=>$this->fileHandler->getObjectId(),"fileDescription"=>$this->fileDescription, "fileType"=>$this->fileHandler->sourceFile->getType(), "searchData"=>$this->getSearchData(), "loc"=>$location, "sidecars"=>$this->sidecars, "isPrimary"=>$this->isPrimary]);
+			return array_merge($dateData, ["fileId"=>$this->fileHandler->getObjectId(),"fileDescription"=>$this->fileDescription, "fileType"=>$this->fileHandler->sourceFile->getType(), "searchData"=>$this->getSearchData(), "loc"=>$location, "sidecars"=>$this->sidecars, "isPrimary"=>$this->isPrimary, "uuid"=>$this->uuid]);
 		}
 		else {
 			return array();

--- a/application/models/widget_contents/Widget_contents_base.php
+++ b/application/models/widget_contents/Widget_contents_base.php
@@ -5,6 +5,8 @@ class Widget_contents_base extends CI_Model {
 
 	public $fieldContents = NULL;
 	public $isPrimary = FALSE;
+	// client-minted identity for a content entry, stable across saves
+	public $uuid = NULL;
 	public $parentObjectId = NULL;
 	public $parentWidget = NULL;
 	public $parentObject = NULL;
@@ -16,7 +18,7 @@ class Widget_contents_base extends CI_Model {
 		}
 
 	public function getAsArray($serializeNestedObjects=false) {
-		return ["fieldContents"=>$this->fieldContents, "isPrimary"=>$this->isPrimary];
+		return ["fieldContents"=>$this->fieldContents, "isPrimary"=>$this->isPrimary, "uuid"=>$this->uuid];
 	}
 
 	public function getAsText($serializeNestedObjects=false) {


### PR DESCRIPTION
This persists any client minted uuids on widgets server-side. Any existing widgets return null uuid until saved by client. This supports a forthcoming asset editor refactor to make change tracking easier and handle race conditions (e.g. client changes before server response).

