### PR TITLE
add setting for showAssetLastModifiedDate

### DIFF
--- a/application/controllers/Home.php
+++ b/application/controllers/Home.php
@@ -271,7 +271,7 @@ class Home extends Instance_Controller {
 
 		$headerData['showChildCollections'] = $this->instance->getShowChildCollections();
 
-    $headerData['showAssetLastModifiedDate'] = $this->instance->getShowAssetLastModifiedDate();
+		$headerData['showAssetLastModifiedDate'] = $this->instance->getShowAssetLastModifiedDate();
 
 		$headerData['theming'] = [
 			'availableThemes' => $this->instance->getAvailableThemes(),

--- a/application/controllers/Home.php
+++ b/application/controllers/Home.php
@@ -271,6 +271,8 @@ class Home extends Instance_Controller {
 
 		$headerData['showChildCollections'] = $this->instance->getShowChildCollections();
 
+    $headerData['showAssetLastModifiedDate'] = $this->instance->getShowAssetLastModifiedDate();
+
 		$headerData['theming'] = [
 			'availableThemes' => $this->instance->getAvailableThemes(),
 			'enabled' => $this->instance->getEnableThemes(),

--- a/application/controllers/Instances.php
+++ b/application/controllers/Instances.php
@@ -55,7 +55,7 @@ class Instances extends Instance_Controller
 			'defaultTheme' => $instance->getDefaultTheme(),
 			'availableThemes' => $instance->getAvailableThemes(),
 			'showChildCollections' => $instance->getShowChildCollections(),
-      'showAssetLastModifiedDate' => $instance->getShowAssetLastModifiedDate(),
+			'showAssetLastModifiedDate' => $instance->getShowAssetLastModifiedDate(),
 			'showThumbnailDescription' => $instance->getShowThumbnailDescription(),
 			'customHomeRedirect' => $instance->getCustomHomeRedirect(),
 			'maximumMoreLikeThis' => $instance->getMaximumMoreLikeThis(),
@@ -157,7 +157,7 @@ class Instances extends Instance_Controller
 		$instance->setDefaultTheme($this->input->post('defaultTheme'));
 		$instance->setAvailableThemes($this->input->post('availableThemes'));
 		$instance->setShowChildCollections($this->input->post('showChildCollections') ? true : false);
-    $instance->setShowAssetLastModifiedDate($this->input->post('showAssetLastModifiedDate') ? true : false);
+		$instance->setShowAssetLastModifiedDate($this->input->post('showAssetLastModifiedDate') ? true : false);
 		$instance->setShowThumbnailDescription($this->input->post('showThumbnailDescription') ? true : false);
 		$instance->setCustomHomeRedirect($this->input->post('customHomeRedirect'));
 		$instance->setMaximumMoreLikeThis($this->input->post('maximumMoreLikeThis'));

--- a/application/controllers/Instances.php
+++ b/application/controllers/Instances.php
@@ -55,6 +55,7 @@ class Instances extends Instance_Controller
 			'defaultTheme' => $instance->getDefaultTheme(),
 			'availableThemes' => $instance->getAvailableThemes(),
 			'showChildCollections' => $instance->getShowChildCollections(),
+      'showAssetLastModifiedDate' => $instance->getShowAssetLastModifiedDate(),
 			'showThumbnailDescription' => $instance->getShowThumbnailDescription(),
 			'customHomeRedirect' => $instance->getCustomHomeRedirect(),
 			'maximumMoreLikeThis' => $instance->getMaximumMoreLikeThis(),
@@ -156,6 +157,7 @@ class Instances extends Instance_Controller
 		$instance->setDefaultTheme($this->input->post('defaultTheme'));
 		$instance->setAvailableThemes($this->input->post('availableThemes'));
 		$instance->setShowChildCollections($this->input->post('showChildCollections') ? true : false);
+    $instance->setShowAssetLastModifiedDate($this->input->post('showAssetLastModifiedDate') ? true : false);
 		$instance->setShowThumbnailDescription($this->input->post('showThumbnailDescription') ? true : false);
 		$instance->setCustomHomeRedirect($this->input->post('customHomeRedirect'));
 		$instance->setMaximumMoreLikeThis($this->input->post('maximumMoreLikeThis'));

--- a/application/models/Entity/Instance.php
+++ b/application/models/Entity/Instance.php
@@ -1318,6 +1318,7 @@ class Instance
         $defaults = [
             'showChildCollections' => true,
             'showThumbnailDescription' => false,
+            'showAssetLastModifiedDate' => false,
         ];
 
         return array_merge($defaults, $this->additionalSettings ?? []);
@@ -1344,11 +1345,17 @@ class Instance
         return $this;
     }
 
+    /**
+     * Whether an asset's last-modified date appears alongside it.
+     */
     public function getShowAssetLastModifiedDate(): bool
     {
-        return (bool) $this->getAdditionalSettings()['showAssetLastModifiedDate'] ?? false;
+        return (bool) $this->getAdditionalSettings()['showAssetLastModifiedDate'];
     }
 
+    /**
+     * Write showAssetLastModifiedDate into the stored blob, preserving sibling keys.
+     */
     public function setShowAssetLastModifiedDate(bool $value): self
     {
         $this->additionalSettings = array_merge(

--- a/application/models/Entity/Instance.php
+++ b/application/models/Entity/Instance.php
@@ -1344,6 +1344,21 @@ class Instance
         return $this;
     }
 
+    public function getShowAssetLastModifiedDate(): bool
+    {
+        return (bool) $this->getAdditionalSettings()['showAssetLastModifiedDate'] ?? false;
+    }
+
+    public function setShowAssetLastModifiedDate(bool $value): self
+    {
+        $this->additionalSettings = array_merge(
+            $this->additionalSettings ?? [],
+            ['showAssetLastModifiedDate' => $value]
+        );
+
+        return $this;
+    }
+
     /**
      * Whether the description text appears below an asset's thumbnail.
      */


### PR DESCRIPTION
Adds a setting to the `additionalSettings` jsonb column for `showAssetLastModifiedDate` and returns it to our instance settings and instance nav endpoints. See https://github.com/UMN-LATIS/elevator-ui/issues/654

